### PR TITLE
change Api: Non-empty LVar

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,9 @@
+
+## Unreleased
+
+- Auto re-mount on unhandled folder events
+- API refactor (No LVar) - [#1](https://github.com/srid/unionmount/pull/1)
+
+## 0.1.0.0
+
+- Initial release

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             overrides = self: super: with pkgs.haskell.lib; {
               # Use callCabal2nix to override Haskell dependencies here
               # cf. https://tek.brick.do/K3VXJd8mEKO7
+              relude = self.callHackage "relude" "1.0.0.1" { }; # Not on nixpkgs, for some reason.
             };
             modifier = drv:
               pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages;

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ ];
-        pkgs =
-          import nixpkgs { inherit system overlays; config.allowBroken = true; };
+        pkgs = nixpkgs.legacyPackages.${system};
         project = returnShellEnv:
           pkgs.haskellPackages.developPackage {
             inherit returnShellEnv;
@@ -25,16 +24,16 @@
               relude = self.callHackage "relude" "1.0.0.1" { }; # Not on nixpkgs, for some reason.
             };
             modifier = drv:
-              pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages;
-              [
-                # Specify your build/dev dependencies here. 
-                cabal-fmt
-                cabal-install
-                ghcid
-                haskell-language-server
-                ormolu
-                pkgs.nixpkgs-fmt
-              ]);
+              pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages; pkgs.lib.lists.optional returnShellEnv
+                [
+                  # Specify your build/dev dependencies here. 
+                  cabal-fmt
+                  cabal-install
+                  ghcid
+                  haskell-language-server
+                  ormolu
+                  pkgs.nixpkgs-fmt
+                ]);
           };
       in
       {

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -151,17 +151,19 @@ data Cmd
   deriving (Eq, Show)
 
 unionMount ::
-  forall source tag m.
+  forall source tag m m1.
   ( MonadIO m,
     MonadUnliftIO m,
     MonadLogger m,
+    MonadLogger m1,
+    MonadIO m1,
     Ord source,
     Ord tag
   ) =>
   Set (source, FilePath) ->
   [(tag, FilePattern)] ->
   [FilePattern] ->
-  m
+  m1
     ( Change source tag,
       (Change source tag -> m ()) ->
       m Cmd

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -34,6 +34,56 @@ import System.FilePattern.Directory (getDirectoryFilesIgnore)
 import UnliftIO (MonadUnliftIO, finally, newTBQueueIO, race_, try, withRunInIO, writeTBQueue)
 import UnliftIO.STM (TBQueue, readTBQueue)
 
+-- | Simplified variation of `unionMountOnLVar` with exactly one source.
+mountOnLVar ::
+  forall model m b.
+  ( MonadIO m,
+    MonadUnliftIO m,
+    MonadLogger m,
+    Show b,
+    Ord b
+  ) =>
+  -- | The directory to mount.
+  FilePath ->
+  -- | Only include these files (exclude everything else)
+  [(b, FilePattern)] ->
+  -- | Ignore these patterns
+  [FilePattern] ->
+  -- | The `LVar` onto which to mount.
+  --
+  -- NOTE: It must not be set already. Otherwise, the value will be overriden
+  -- with the initial value argument (next).
+  -- LVar model ->
+  -- | Initial value of model, onto which to apply updates.
+  model ->
+  -- | How to update the model given a file action.
+  --
+  -- `b` is the tag associated with the `FilePattern` that selected this
+  -- `FilePath`. `FileAction` is the operation performed on this path. This
+  -- should return a function (in monadic context) that will update the model,
+  -- to reflect the given `FileAction`.
+  --
+  -- If the action throws an exception, it will be logged and ignored.
+  (b -> FilePath -> FileAction () -> m (model -> model)) ->
+  m (NonEmptyLVar m model)
+mountOnLVar folder pats ignore var0 toAction' =
+  let tag0 = ()
+      sources = one (tag0, folder)
+   in unionMountOnLVar sources pats ignore var0 $ \ch -> do
+        let fsSet = (fmap . fmap . fmap . fmap) void $ fmap Map.toList <$> Map.toList ch
+        (\(tag, xs) -> uncurry (toAction' tag) `chainM` xs) `chainM` fsSet
+  where
+    -- Monadic version of `chain`
+    chainM :: Monad m => (x -> m (a -> a)) -> [x] -> m (a -> a)
+    chainM f =
+      fmap chain . mapM f
+      where
+        -- Apply the list of actions in the given order to an initial argument.
+        --
+        -- chain [f1, f2, ...] a = ... (f2 (f1 x))
+        chain :: [a -> a] -> a -> a
+        chain = flip $ foldl' $ flip ($)
+
 -- | Like `unionMount` but updates a `LVar` as well handles exceptions (and
 -- unhandled events) by logging them.
 unionMountOnLVar ::
@@ -150,56 +200,6 @@ unionMount sources pats ignore = do
                             loop
               loop
       )
-
--- | Simplified variation of `unionMountOnLVar` with exactly one source.
-mountOnLVar ::
-  forall model m b.
-  ( MonadIO m,
-    MonadUnliftIO m,
-    MonadLogger m,
-    Show b,
-    Ord b
-  ) =>
-  -- | The directory to mount.
-  FilePath ->
-  -- | Only include these files (exclude everything else)
-  [(b, FilePattern)] ->
-  -- | Ignore these patterns
-  [FilePattern] ->
-  -- | The `LVar` onto which to mount.
-  --
-  -- NOTE: It must not be set already. Otherwise, the value will be overriden
-  -- with the initial value argument (next).
-  -- LVar model ->
-  -- | Initial value of model, onto which to apply updates.
-  model ->
-  -- | How to update the model given a file action.
-  --
-  -- `b` is the tag associated with the `FilePattern` that selected this
-  -- `FilePath`. `FileAction` is the operation performed on this path. This
-  -- should return a function (in monadic context) that will update the model,
-  -- to reflect the given `FileAction`.
-  --
-  -- If the action throws an exception, it will be logged and ignored.
-  (b -> FilePath -> FileAction () -> m (model -> model)) ->
-  m (NonEmptyLVar m model)
-mountOnLVar folder pats ignore var0 toAction' =
-  let tag0 = ()
-      sources = one (tag0, folder)
-   in unionMountOnLVar sources pats ignore var0 $ \ch -> do
-        let fsSet = (fmap . fmap . fmap . fmap) void $ fmap Map.toList <$> Map.toList ch
-        (\(tag, xs) -> uncurry (toAction' tag) `chainM` xs) `chainM` fsSet
-  where
-    -- Monadic version of `chain`
-    chainM :: Monad m => (x -> m (a -> a)) -> [x] -> m (a -> a)
-    chainM f =
-      fmap chain . mapM f
-      where
-        -- Apply the list of actions in the given order to an initial argument.
-        --
-        -- chain [f1, f2, ...] a = ... (f2 (f1 x))
-        chain :: [a -> a] -> a -> a
-        chain = flip $ foldl' $ flip ($)
 
 filesMatching :: (MonadIO m, MonadLogger m) => FilePath -> [FilePattern] -> [FilePattern] -> m [FilePath]
 filesMatching parent' pats ignore = do

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -276,13 +276,14 @@ unionMount sources pats ignore = do
                       let shouldIgnore = any (?== fp) ignore
                       case actE of
                         Left _ -> do
+                          let reason = "Unhandled folder event on '" <> toText fp <> "'"
                           if shouldIgnore
                             then do
-                              log LevelWarn "Unhandled folder event on an ignored path"
+                              log LevelWarn $ reason <> " on an ignored path"
                               loop
                             else do
                               -- We don't know yet how to deal with folder events. Just reboot the mount.
-                              log LevelWarn "Unhandled folder event; suggesting a re-mount"
+                              log LevelWarn $ reason <> "; suggesting a re-mount"
                               pure Cmd_Remount -- Exit, asking user to remokunt
                         Right act -> do
                           case guard (not shouldIgnore) >> getTag pats fp of

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -112,7 +112,7 @@ unionMountOnLVar sources pats ignore model0 handleAction = do
   -- /after/ the initial file listing is read, and `modify` is called for each
   -- subsequent inotify events.
   (x0, xf) <- unionMount sources pats ignore
-  x0' <- handleAction x0
+  x0' <- interceptExceptions id $ handleAction x0
   pure
     ( x0' model0,
       \lvar -> do
@@ -128,7 +128,7 @@ interceptExceptions :: (MonadIO m, MonadUnliftIO m, MonadLogger m) => a -> m a -
 interceptExceptions default_ f = do
   try f >>= \case
     Left (ex :: SomeException) -> do
-      log LevelError $ "User exception: " <> show ex
+      log LevelError $ "Change handler exception: " <> show ex
       pure default_
     Right v ->
       pure v
@@ -325,7 +325,7 @@ watchTreeM wm fp pr f =
     watchTree wm fp pr $ \evt -> run (f evt)
 
 log :: MonadLogger m => LogLevel -> Text -> m ()
-log = logWithoutLoc "Ema.Helper.FileSystem"
+log = logWithoutLoc "System.UnionMount"
 
 -- TODO: Abstract in module with StateT / MonadState
 newtype OverlayFs source = OverlayFs

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -31,7 +31,7 @@ import System.FSNotify
 import System.FilePath (isRelative, makeRelative)
 import System.FilePattern (FilePattern, (?==))
 import System.FilePattern.Directory (getDirectoryFilesIgnore)
-import UnliftIO (MonadUnliftIO, newTBQueueIO, race, try, withRunInIO, writeTBQueue)
+import UnliftIO (MonadUnliftIO, finally, newTBQueueIO, race, try, withRunInIO, writeTBQueue)
 import UnliftIO.STM (TBQueue, readTBQueue)
 
 -- | Simplified variation of `unionMountOnLVar` with exactly one source.
@@ -387,13 +387,10 @@ onChange q roots = do
             Modified (rel -> fp) _ _ -> f x fp $ Right $ Refresh Update ()
             Removed (rel -> fp) _ _ -> f x fp $ Right Delete
             Unknown (rel -> fp) _ _ -> f x fp $ Right Delete
-    let _stopWatcher :: m ()
-        _stopWatcher = do
-          log LevelInfo "Stopping fsnotify monitor."
-          liftIO $ forM_ stops id
     liftIO (threadDelay maxBound)
-    -- TODO: Not using this, for verifying https://github.com/ndmitchell/ghcid/issues/194
-    -- `finally` stopWatcher
+      `finally` do
+        log LevelInfo "Stopping fsnotify monitor."
+        liftIO $ forM_ stops id
     -- Unreachable
     pure Cmd_Remount
 

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               unionmount
-version:            0.1.0.0
+version:            0.2.0.0
 license:            MIT
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -9,14 +9,13 @@ category:           Filesystem
 
 -- TODO: Before hackage release.
 -- A short (one-line) description of the package.
-synopsis: Union mount filesystem paths into Haskell datastructures
+synopsis:           Union mount filesystem paths into Haskell datastructures
 
 -- A longer description of the package.
-description: Union mount filesystem paths into Haskell datastructures
+description:        Union mount filesystem paths into Haskell datastructures
 
 -- A URL where users can report bugs.
-bug-reports: https://github.com/srid/unionmount
-
+bug-reports:        https://github.com/srid/unionmount
 extra-source-files:
   LICENSE
   README.md
@@ -24,7 +23,7 @@ extra-source-files:
 library
   build-depends:
     , async
-    , base >=4.13.0.0 && <=4.17.0.0
+    , base          >=4.13.0.0 && <=4.17.0.0
     , bytestring
     , containers
     , data-default


### PR DESCRIPTION
- Replace LVar with `m (model, (model -> m ()) -> m ())` for https://github.com/srid/ema/pull/81
- Export only what's necessary
- Auto re-mount on unhandled folder events