### PR TITLE
Update to fsnotify `0.4+`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 
+## 0.2.0.1
+
+- Update fsnotify
+- Write a simple debouncer for files (fsnotify's debouncer was removed upstream). This is better than the removed upstream debouncer because it works like the proposed state machine. 
+
 ## 0.2.0.0
 
 - Auto re-mount on unhandled folder events

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
 
 ## 0.2.1.0
 
-- Update fsnotify
-- Write a simple debouncer for files (fsnotify's debouncer was removed upstream). This is better than the removed upstream debouncer because it works like the proposed state machine. 
+- Now requires fsnotify >= 0.4
+  - Write a simple debouncer for files (fsnotify's debouncer was removed upstream). This is better than the removed upstream debouncer because it works like the proposed state machine. 
 
 ## 0.2.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 
-## 0.2.0.1
+## 0.2.1.0
 
 - Update fsnotify
 - Write a simple debouncer for files (fsnotify's debouncer was removed upstream). This is better than the removed upstream debouncer because it works like the proposed state machine. 

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1683063956,
-        "narHash": "sha256-3kkFO2MOjuHxNqo0ZmxEjUnH34/0zkFpmsqjtRMGKkg=",
+        "lastModified": 1690398210,
+        "narHash": "sha256-1wnx2K3U2xmUI5rUulOZ66tcIva+OGWS47dyHdZJjsA=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "a72d4c3a4e9656766f5a5315ac5358417d21b78e",
+        "rev": "d3c8d8be31d3a5dcf9d49e9dacfc570b5c736658",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683442750,
-        "narHash": "sha256-IiJ0WWW6OcCrVFl1ijE+gTaP0ChFfV6dNkJR05yStmw=",
+        "lastModified": 1691464053,
+        "narHash": "sha256-D21ctOBjr2Y3vOFRXKRoFr6uNBvE8q5jC4RrMxRZXTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb751d65225ec53de9cf3d88acbf08d275882389",
+        "rev": "844ffa82bbe2a2779c86ab3a72ff1b4176cec467",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,13 @@
           devShell.tools = hp: {
             treefmt = config.treefmt.build.wrapper;
           } // config.treefmt.build.programs;
+          packages = {
+            fsnotify.source = "0.4.1.0"; # Not in nixpkgs, yet.
+            ghcid.source = "0.8.8"; # For fsnotify dep
+          };
+          settings = {
+            fsnotify.check = false;
+          };
         };
 
         packages.default = self'.packages.unionmount;

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -23,14 +23,14 @@ extra-source-files:
 library
   build-depends:
     , async
-    , base          >=4.13.0.0 && <=4.17.0.0
+    , base          >=4.13.0 && <4.18
     , bytestring
     , containers
     , data-default
     , directory
     , filepath
     , filepattern
-    , fsnotify
+    , fsnotify      >=0.4.0  && <0.5
     , lvar
     , monad-logger
     , mtl

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               unionmount
-version:            0.2.0.0
+version:            0.2.0.1
 license:            MIT
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               unionmount
-version:            0.2.0.1
+version:            0.2.1.0
 license:            MIT
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
This fixes some issues for me related to saving ~large files (like 100kb) with Emacs, like Vim it seems to have a weird way of writing (first it writes an empty file then fill it up, apparently). The previous hfsnotify's debouncer would only report the first write and the file would appear empty sometimes.