### PR TITLE
Deal with bad symlinks

### DIFF
--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -15,6 +15,7 @@ import System.Directory (createDirectory)
 import System.Directory.Recursive (getFilesRecursive)
 import System.FilePath ((</>))
 import System.FilePattern (FilePattern)
+import System.Posix.Files
 import System.UnionMount qualified as UM
 import Test.Hspec
 import UnliftIO (MonadUnliftIO)
@@ -38,6 +39,17 @@ spec = do
             ( do
                 writeFile "file1" "hello, again"
                 writeFile "file2" "another file"
+            )
+    it "bad-symlink" $ do
+      unionMountSpec $
+        one $
+          FolderMutation
+            Nothing
+            ( do
+                createSymbolicLink "/nonexistent" "alink"
+            )
+            ( do
+                writeFile "file1" "hello"
             )
     it "deletion" $ do
       unionMountSpec $

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -82,6 +82,7 @@ test-suite test
     , hspec
     , monad-logger
     , monad-logger-extras
+    , unix
     , relude
 
   if flag(ghcid)


### PR DESCRIPTION
- [x] Reproduce the bug
- [ ] Fix it

```
ghci> withManagerM $ \mgr -> watchTreeM mgr "/home/srid/test" (const True) $ \event -> putStrLn (show event)
*** Exception: /home/srid/test/.pa/alink: getFileStatus: does not exist (No such file or directory)
```