### PR TITLE
Broaden test coverage and harden fsnotify harness

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 
-## Unreleased
+## 0.4.0.0
 
 - Broaden test coverage; expose pure internals as `System.UnionMount.Internal` (#15)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 
+## Unreleased
+
+- Broaden test coverage; expose pure internals as `System.UnionMount.Internal` (#15)
+
 ## 0.3.0.0
 
 - Support for custom mount points (#6)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 
-## 0.4.0.0
+## Unreleased
 
 - Broaden test coverage; expose pure internals as `System.UnionMount.Internal` (#15)
 

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -14,6 +14,12 @@ module System.UnionMount
 
     -- * For tests
     chainM,
+    getTag,
+    OverlayFs,
+    emptyOverlayFs,
+    overlayFsAdd,
+    overlayFsRemove,
+    overlayFsLookup,
   )
 where
 

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -14,12 +14,6 @@ module System.UnionMount
 
     -- * For tests
     chainM,
-    getTag,
-    OverlayFs,
-    emptyOverlayFs,
-    overlayFsAdd,
-    overlayFsRemove,
-    overlayFsLookup,
   )
 where
 
@@ -31,7 +25,6 @@ import Control.Monad.Logger
   )
 import Data.LVar qualified as LVar
 import Data.Map.Strict qualified as Map
-import Data.Set qualified as Set
 import System.Directory (canonicalizePath)
 import System.FSNotify
   ( ActionPredicate,
@@ -45,9 +38,17 @@ import System.FSNotify
     watchTree,
     withManagerConf,
   )
-import System.FilePath (isRelative, makeRelative, (</>))
+import System.FilePath (makeRelative, (</>))
 import System.FilePattern (FilePattern, (?==))
 import System.FilePattern.Directory (getDirectoryFilesIgnore)
+import System.UnionMount.Internal
+  ( OverlayFs,
+    emptyOverlayFs,
+    getTag,
+    overlayFsAdd,
+    overlayFsLookup,
+    overlayFsRemove,
+  )
 import UnliftIO (MonadUnliftIO, finally, race, try, withRunInIO)
 
 -- | Simplified version of `unionMount` with exactly one layer.
@@ -241,21 +242,6 @@ filesMatchingWithTag parent' pats ignore = do
           pure (tag, one fp)
   pure $ Map.toList m
 
-getTag :: [(b, FilePattern)] -> FilePath -> Maybe b
-getTag pats fp =
-  let pull patterns =
-        listToMaybe $
-          flip mapMaybe patterns $ \(tag, pat) -> do
-            guard $ pat ?== fp
-            pure tag
-   in if isRelative fp
-        then pull pats
-        else -- `fp` is an absolute path (because of use of symlinks), so let's
-        -- be more lenient in matching it. Note that this does meat we might
-        -- match files the user may not have originally intended. This is
-        -- the trade offs with using symlinks.
-          pull $ second ("**/" <>) <$> pats
-
 data RefreshAction
   = -- | No recent change. Just notifying of file's existance
     Existing
@@ -356,31 +342,6 @@ watchTreeM wm fp pr f =
 
 log :: (MonadLogger m) => LogLevel -> Text -> m ()
 log = logWithoutLoc "System.UnionMount"
-
--- TODO: Abstract in module with StateT / MonadState
-newtype OverlayFs source = OverlayFs (Map FilePath (Set (source, FilePath)))
-
--- TODO: Replace this with a function taking `NonEmpty source`
-emptyOverlayFs :: (Ord source) => OverlayFs source
-emptyOverlayFs = OverlayFs mempty
-
-overlayFsModify :: FilePath -> (Set (src, FilePath) -> Set (src, FilePath)) -> OverlayFs src -> OverlayFs src
-overlayFsModify k f (OverlayFs m) =
-  OverlayFs $
-    Map.insert k (f $ fromMaybe Set.empty $ Map.lookup k m) m
-
-overlayFsAdd :: (Ord src) => FilePath -> (src, FilePath) -> OverlayFs src -> OverlayFs src
-overlayFsAdd fp src =
-  overlayFsModify fp $ Set.insert src
-
-overlayFsRemove :: (Ord src) => FilePath -> (src, FilePath) -> OverlayFs src -> OverlayFs src
-overlayFsRemove fp src =
-  overlayFsModify fp $ Set.delete src
-
-overlayFsLookup :: FilePath -> OverlayFs source -> Maybe (NonEmpty ((source, FilePath), FilePath))
-overlayFsLookup fp (OverlayFs m) = do
-  sources <- nonEmpty . toList =<< Map.lookup fp m
-  pure $ sources <&> (,fp)
 
 -- Files matched by each tag pattern, each represented by their corresponding
 -- file (absolute path) in the individual sources. It is up to the user to union

--- a/src/System/UnionMount/Internal.hs
+++ b/src/System/UnionMount/Internal.hs
@@ -1,0 +1,68 @@
+-- | Internal helpers used by "System.UnionMount" and its test suite.
+--
+-- These are exposed as an internal module rather than re-exported from
+-- "System.UnionMount" so that they are discoverable to tests without
+-- polluting the public API. Stability is not guaranteed across versions.
+module System.UnionMount.Internal
+  ( -- * Tag resolution
+    getTag,
+
+    -- * Overlay filesystem
+    OverlayFs,
+    emptyOverlayFs,
+    overlayFsModify,
+    overlayFsAdd,
+    overlayFsRemove,
+    overlayFsLookup,
+  )
+where
+
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import System.FilePath (isRelative)
+import System.FilePattern (FilePattern, (?==))
+
+-- | Resolve the first tag whose pattern matches @fp@.
+--
+-- If @fp@ is an absolute path (which can happen when the mount directory
+-- contains symlinks), patterns are implicitly prefixed with @**/@ so that
+-- the tail of the path can still match.
+getTag :: [(b, FilePattern)] -> FilePath -> Maybe b
+getTag pats fp =
+  let pull patterns =
+        listToMaybe $
+          flip mapMaybe patterns $ \(tag, pat) -> do
+            guard $ pat ?== fp
+            pure tag
+   in if isRelative fp
+        then pull pats
+        else -- `fp` is an absolute path (because of use of symlinks), so let's
+        -- be more lenient in matching it. Note that this does mean we might
+        -- match files the user may not have originally intended. This is
+        -- the trade off with using symlinks.
+          pull $ second ("**/" <>) <$> pats
+
+-- TODO: Abstract in module with StateT / MonadState
+newtype OverlayFs source = OverlayFs (Map FilePath (Set (source, FilePath)))
+
+-- TODO: Replace this with a function taking `NonEmpty source`
+emptyOverlayFs :: (Ord source) => OverlayFs source
+emptyOverlayFs = OverlayFs mempty
+
+overlayFsModify :: FilePath -> (Set (src, FilePath) -> Set (src, FilePath)) -> OverlayFs src -> OverlayFs src
+overlayFsModify k f (OverlayFs m) =
+  OverlayFs $
+    Map.insert k (f $ fromMaybe Set.empty $ Map.lookup k m) m
+
+overlayFsAdd :: (Ord src) => FilePath -> (src, FilePath) -> OverlayFs src -> OverlayFs src
+overlayFsAdd fp src =
+  overlayFsModify fp $ Set.insert src
+
+overlayFsRemove :: (Ord src) => FilePath -> (src, FilePath) -> OverlayFs src -> OverlayFs src
+overlayFsRemove fp src =
+  overlayFsModify fp $ Set.delete src
+
+overlayFsLookup :: FilePath -> OverlayFs source -> Maybe (NonEmpty ((source, FilePath), FilePath))
+overlayFsLookup fp (OverlayFs m) = do
+  sources <- nonEmpty . toList =<< Map.lookup fp m
+  pure $ sources <&> (,fp)

--- a/test/System/UnionMount/PropSpec.hs
+++ b/test/System/UnionMount/PropSpec.hs
@@ -1,0 +1,83 @@
+module System.UnionMount.PropSpec where
+
+import Data.ByteString qualified as BS
+import Data.List.NonEmpty qualified as NE
+import Data.Set qualified as Set
+import System.UnionMountSpec (FolderMutation (..), unionMountSpec)
+import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+import UnliftIO.Directory (doesFileExist, removeFile)
+
+spec :: Spec
+spec = describe "unionMount (property)" $ do
+  -- fsnotify-based tests are expensive (~0.5s each), so we cap the
+  -- number of cases. This is enough to catch regressions in the
+  -- model-vs-IO equivalence invariant without ballooning CI time.
+  modifyMaxSuccess (const 15) $
+    prop "final model equals the IO-materialized state" $
+      \(UnionFolderMutationSpec specs) ->
+        unionMountSpec (toFolderMutation <$> specs)
+
+-- | Pure description of a file-system operation in a folder.
+data FileOp
+  = WriteF FilePath ByteString
+  | RemoveF FilePath
+  deriving (Show, Eq)
+
+-- | Pure description of a `FolderMutation`.
+data FolderMutationSpec = FolderMutationSpec
+  { fmsMountPoint :: Maybe FilePath,
+    fmsInitOps :: [FileOp],
+    fmsUpdateOps :: [FileOp]
+  }
+  deriving (Show, Eq)
+
+-- | Non-empty list of folder mutation specs (one per layer).
+newtype UnionFolderMutationSpec = UnionFolderMutationSpec (NonEmpty FolderMutationSpec)
+  deriving (Show)
+
+instance Arbitrary FolderMutationSpec where
+  arbitrary = do
+    mp <- oneof [pure Nothing, Just <$> elements ["foo", "bar"]]
+    (initOps, afterInit) <- genOps mempty
+    (updateOps, _) <- genOps afterInit
+    pure $ FolderMutationSpec mp initOps updateOps
+
+instance Arbitrary UnionFolderMutationSpec where
+  arbitrary = do
+    k <- choose (1, 3)
+    UnionFolderMutationSpec . NE.fromList <$> vectorOf k arbitrary
+
+-- | Generate a sequence of ops. `RemoveF` is only emitted when the target
+-- file has been written by an earlier op in the same sequence (or is in
+-- the initial set), so the generated IO is safe to run.
+genOps :: Set FilePath -> Gen ([FileOp], Set FilePath)
+genOps = go (4 :: Int)
+  where
+    go 0 present = pure ([], present)
+    go k present = do
+      op <-
+        if Set.null present
+          then genWrite
+          else frequency [(3, genWrite), (1, RemoveF <$> elements (Set.toList present))]
+      let present' = case op of
+            WriteF fp _ -> Set.insert fp present
+            RemoveF fp -> Set.delete fp present
+      (rest, final) <- go (k - 1) present'
+      pure (op : rest, final)
+    genWrite = WriteF <$> elements ["a", "b", "c", "d"] <*> genContent
+    genContent = BS.pack <$> listOf (elements [0x41 .. 0x5A])
+
+runFileOp :: FileOp -> IO ()
+runFileOp = \case
+  WriteF fp bs -> BS.writeFile fp bs
+  RemoveF fp -> whenM (doesFileExist fp) $ removeFile fp
+
+toFolderMutation :: FolderMutationSpec -> FolderMutation
+toFolderMutation s =
+  FolderMutation
+    { _folderMountPoint = fmsMountPoint s,
+      _folderMutationInit = traverse_ runFileOp (fmsInitOps s),
+      _folderMutationUpdate = traverse_ runFileOp (fmsUpdateOps s)
+    }

--- a/test/System/UnionMount/UnitSpec.hs
+++ b/test/System/UnionMount/UnitSpec.hs
@@ -1,0 +1,71 @@
+module System.UnionMount.UnitSpec where
+
+import Data.List.NonEmpty qualified as NE
+import System.UnionMount qualified as UM
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "chainM" $ do
+    it "identity on empty input" $ do
+      f <- UM.chainM (\x -> pure (+ x)) ([] :: [Int])
+      f (10 :: Int) `shouldBe` 10
+    it "applies functions in left-to-right order" $ do
+      -- Each element produces a function that appends itself; left-to-right
+      -- order means the first element is applied first.
+      f <- UM.chainM (\c -> pure (<> [c])) "abc"
+      f "" `shouldBe` "abc"
+    it "monadic effects run once per element" $ do
+      ref <- newIORef (0 :: Int)
+      _ <- UM.chainM (\_ -> modifyIORef' ref (+ 1) >> pure (id :: Int -> Int)) [(), (), ()]
+      readIORef ref `shouldReturn` 3
+
+  describe "getTag" $ do
+    let pats = [(1 :: Int, "*.md"), (2, "*.txt")]
+    it "tags a matching relative path" $ do
+      UM.getTag pats "foo.md" `shouldBe` Just 1
+      UM.getTag pats "foo.txt" `shouldBe` Just 2
+    it "returns Nothing when no pattern matches" $ do
+      UM.getTag pats "foo.hs" `shouldBe` Nothing
+    it "picks the first matching pattern" $ do
+      -- Overlapping patterns: first one wins.
+      let overlap = [(1 :: Int, "*.md"), (2, "foo.md")]
+      UM.getTag overlap "foo.md" `shouldBe` Just 1
+    it "matches absolute paths via an implicit **/ prefix" $ do
+      UM.getTag pats "/tmp/some/where/foo.md" `shouldBe` Just 1
+
+  describe "OverlayFs" $ do
+    let ofs0 = UM.emptyOverlayFs :: UM.OverlayFs String
+    it "lookup on empty returns Nothing" $ do
+      UM.overlayFsLookup "file" ofs0 `shouldBe` Nothing
+    it "add then lookup returns the single source" $ do
+      let ofs = UM.overlayFsAdd "file" ("A", "file") ofs0
+      fmap NE.toList (UM.overlayFsLookup "file" ofs)
+        `shouldBe` Just [(("A", "file"), "file")]
+    it "lookup of unrelated file still returns Nothing" $ do
+      let ofs = UM.overlayFsAdd "file" ("A", "file") ofs0
+      UM.overlayFsLookup "other" ofs `shouldBe` Nothing
+    it "multiple sources are all returned" $ do
+      let ofs =
+            UM.overlayFsAdd "file" ("A", "file") $
+              UM.overlayFsAdd "file" ("B", "file") ofs0
+      fmap (sort . NE.toList) (UM.overlayFsLookup "file" ofs)
+        `shouldBe` Just [(("A", "file"), "file"), (("B", "file"), "file")]
+    it "remove deletes a single source, leaving others" $ do
+      let ofs =
+            UM.overlayFsRemove "file" ("B", "file") $
+              UM.overlayFsAdd "file" ("A", "file") $
+                UM.overlayFsAdd "file" ("B", "file") ofs0
+      fmap NE.toList (UM.overlayFsLookup "file" ofs)
+        `shouldBe` Just [(("A", "file"), "file")]
+    it "remove of last source makes lookup return Nothing" $ do
+      let ofs =
+            UM.overlayFsRemove "file" ("A", "file") $
+              UM.overlayFsAdd "file" ("A", "file") ofs0
+      UM.overlayFsLookup "file" ofs `shouldBe` Nothing
+    it "remove of a non-existent source is a no-op" $ do
+      let ofs =
+            UM.overlayFsRemove "file" ("B", "file") $
+              UM.overlayFsAdd "file" ("A", "file") ofs0
+      fmap NE.toList (UM.overlayFsLookup "file" ofs)
+        `shouldBe` Just [(("A", "file"), "file")]

--- a/test/System/UnionMount/UnitSpec.hs
+++ b/test/System/UnionMount/UnitSpec.hs
@@ -2,6 +2,7 @@ module System.UnionMount.UnitSpec where
 
 import Data.List.NonEmpty qualified as NE
 import System.UnionMount qualified as UM
+import System.UnionMount.Internal qualified as UMI
 import Test.Hspec
 
 spec :: Spec
@@ -23,49 +24,49 @@ spec = do
   describe "getTag" $ do
     let pats = [(1 :: Int, "*.md"), (2, "*.txt")]
     it "tags a matching relative path" $ do
-      UM.getTag pats "foo.md" `shouldBe` Just 1
-      UM.getTag pats "foo.txt" `shouldBe` Just 2
+      UMI.getTag pats "foo.md" `shouldBe` Just 1
+      UMI.getTag pats "foo.txt" `shouldBe` Just 2
     it "returns Nothing when no pattern matches" $ do
-      UM.getTag pats "foo.hs" `shouldBe` Nothing
+      UMI.getTag pats "foo.hs" `shouldBe` Nothing
     it "picks the first matching pattern" $ do
       -- Overlapping patterns: first one wins.
       let overlap = [(1 :: Int, "*.md"), (2, "foo.md")]
-      UM.getTag overlap "foo.md" `shouldBe` Just 1
+      UMI.getTag overlap "foo.md" `shouldBe` Just 1
     it "matches absolute paths via an implicit **/ prefix" $ do
-      UM.getTag pats "/tmp/some/where/foo.md" `shouldBe` Just 1
+      UMI.getTag pats "/tmp/some/where/foo.md" `shouldBe` Just 1
 
   describe "OverlayFs" $ do
-    let ofs0 = UM.emptyOverlayFs :: UM.OverlayFs String
+    let ofs0 = UMI.emptyOverlayFs :: UMI.OverlayFs String
     it "lookup on empty returns Nothing" $ do
-      UM.overlayFsLookup "file" ofs0 `shouldBe` Nothing
+      UMI.overlayFsLookup "file" ofs0 `shouldBe` Nothing
     it "add then lookup returns the single source" $ do
-      let ofs = UM.overlayFsAdd "file" ("A", "file") ofs0
-      fmap NE.toList (UM.overlayFsLookup "file" ofs)
+      let ofs = UMI.overlayFsAdd "file" ("A", "file") ofs0
+      fmap NE.toList (UMI.overlayFsLookup "file" ofs)
         `shouldBe` Just [(("A", "file"), "file")]
     it "lookup of unrelated file still returns Nothing" $ do
-      let ofs = UM.overlayFsAdd "file" ("A", "file") ofs0
-      UM.overlayFsLookup "other" ofs `shouldBe` Nothing
+      let ofs = UMI.overlayFsAdd "file" ("A", "file") ofs0
+      UMI.overlayFsLookup "other" ofs `shouldBe` Nothing
     it "multiple sources are all returned" $ do
       let ofs =
-            UM.overlayFsAdd "file" ("A", "file") $
-              UM.overlayFsAdd "file" ("B", "file") ofs0
-      fmap (sort . NE.toList) (UM.overlayFsLookup "file" ofs)
+            UMI.overlayFsAdd "file" ("A", "file") $
+              UMI.overlayFsAdd "file" ("B", "file") ofs0
+      fmap (sort . NE.toList) (UMI.overlayFsLookup "file" ofs)
         `shouldBe` Just [(("A", "file"), "file"), (("B", "file"), "file")]
     it "remove deletes a single source, leaving others" $ do
       let ofs =
-            UM.overlayFsRemove "file" ("B", "file") $
-              UM.overlayFsAdd "file" ("A", "file") $
-                UM.overlayFsAdd "file" ("B", "file") ofs0
-      fmap NE.toList (UM.overlayFsLookup "file" ofs)
+            UMI.overlayFsRemove "file" ("B", "file") $
+              UMI.overlayFsAdd "file" ("A", "file") $
+                UMI.overlayFsAdd "file" ("B", "file") ofs0
+      fmap NE.toList (UMI.overlayFsLookup "file" ofs)
         `shouldBe` Just [(("A", "file"), "file")]
     it "remove of last source makes lookup return Nothing" $ do
       let ofs =
-            UM.overlayFsRemove "file" ("A", "file") $
-              UM.overlayFsAdd "file" ("A", "file") ofs0
-      UM.overlayFsLookup "file" ofs `shouldBe` Nothing
+            UMI.overlayFsRemove "file" ("A", "file") $
+              UMI.overlayFsAdd "file" ("A", "file") ofs0
+      UMI.overlayFsLookup "file" ofs `shouldBe` Nothing
     it "remove of a non-existent source is a no-op" $ do
       let ofs =
-            UM.overlayFsRemove "file" ("B", "file") $
-              UM.overlayFsAdd "file" ("A", "file") ofs0
-      fmap NE.toList (UM.overlayFsLookup "file" ofs)
+            UMI.overlayFsRemove "file" ("B", "file") $
+              UMI.overlayFsAdd "file" ("A", "file") ofs0
+      fmap NE.toList (UMI.overlayFsLookup "file" ofs)
         `shouldBe` Just [(("A", "file"), "file")]

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -14,7 +14,7 @@ import Relude.Unsafe qualified as Unsafe
 import System.Directory (createDirectory)
 import System.Directory.Recursive (getFilesRecursive)
 import System.FilePath ((</>))
-import System.FilePattern (FilePattern)
+import System.FilePattern (FilePattern, (?==))
 import System.UnionMount qualified as UM
 import Test.Hspec
 import UnliftIO (MonadUnliftIO)
@@ -25,7 +25,6 @@ import UnliftIO.Temporary (withSystemTempDirectory)
 
 spec :: Spec
 spec = do
-  -- TODO: Use QuickCheck to generate these.
   describe "unionmount" $ do
     it "basic" $ do
       unionMountSpec $
@@ -94,6 +93,57 @@ spec = do
                      writeFile "file3" "file3 is in first layer"
                  )
              ]
+    it "ignore patterns exclude matching files" $ do
+      unionMountSpecWith ["*.ignored"] $
+        one $
+          FolderMutation
+            Nothing
+            ( do
+                writeFile "keep.txt" "keep me"
+                writeFile "drop.ignored" "skip me"
+            )
+            ( do
+                writeFile "keep.txt" "keep me, again"
+                writeFile "also-drop.ignored" "also skip me"
+            )
+    it "delete from top layer reveals lower layer" $ do
+      unionMountSpec $
+        FolderMutation
+          Nothing
+          ( do
+              writeFile "shared" "from lower"
+          )
+          ( pass
+          )
+          :| [ FolderMutation
+                 Nothing
+                 ( do
+                     writeFile "shared" "from upper"
+                 )
+                 ( do
+                     removeFile "shared"
+                 )
+             ]
+  describe "unionMount tags" $ do
+    it "initial scan partitions files by tag pattern" $ do
+      withSystemTempDirectory "multitag" $ \dir -> do
+        writeFile (dir </> "a.md") "md content"
+        writeFile (dir </> "b.txt") "txt content"
+        writeFile (dir </> "c.other") "ignored by patterns"
+        let layers = Set.singleton (dir :: FilePath, (dir, Nothing))
+            pats = [("md" :: String, "*.md"), ("txt", "*.txt")]
+        (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
+          UM.unionMount layers pats [] (mempty :: Map String (Set FilePath)) $ \change ->
+            pure $ \m0 ->
+              Map.foldrWithKey
+                (\tag files -> Map.insertWith Set.union tag (Map.keysSet files))
+                m0
+                change
+        model0
+          `shouldBe` Map.fromList
+            [ ("md", Set.singleton "a.md"),
+              ("txt", Set.singleton "b.txt")
+            ]
 
 -- | Test `UM.unionMount` on a set of folders whose contents/mutations are
 -- represented by a `FolderMutation`, and check that the resulting model is
@@ -103,12 +153,24 @@ unionMountSpec ::
   -- | The folder mutations to test
   UnionFolderMutations ->
   Expectation
-unionMountSpec folders = do
+unionMountSpec = unionMountSpecWith ignoreNone
+
+-- | Like `unionMountSpec`, but with a caller-supplied ignore list that is
+-- passed to `UM.unionMount` and used to filter the IO-materialized expected
+-- model.
+unionMountSpecWith ::
+  [FilePattern] ->
+  UnionFolderMutations ->
+  Expectation
+unionMountSpecWith ignore folders = do
+  -- Compute the expected final state once, using separate temp directories.
+  rawExpected <- runUnionFolderMutations folders
+  let expected = Map.filterWithKey (\fp _ -> not (any (?== fp) ignore)) rawExpected
   withUnionFolderMutations folders $ \tempDirs -> do
     model <- LVar.empty
     flip runLoggerLoggingT logToNowhere $ do
       let layers = Set.fromList $ toList tempDirs <&> \(folder, path) -> (path, (path, _folderMountPoint folder))
-      (model0, patch) <- UM.unionMount layers allFiles ignoreNone mempty $ \change -> do
+      (model0, patch) <- UM.unionMount layers allFiles ignore mempty $ \change -> do
         let files = Unsafe.fromJust $ Map.lookup () change
         flip UM.chainM (Map.toList files) $ \(fp, act) -> do
           case act of
@@ -120,20 +182,46 @@ unionMountSpec folders = do
       LVar.set model model0
       race_
         (patch $ LVar.set model)
-        (withPaddedThreadDelay 500_000 $ updateUnionFolderMutations tempDirs)
+        ( do
+            -- The fsnotify watcher is set up lazily when the sender
+            -- (left side of `race_`) is invoked, so we give it a brief
+            -- head start before mutating files.
+            threadDelay fsnotifyWatcherSetupDelay
+            updateUnionFolderMutations tempDirs
+            -- Poll the model until it reflects the expected final state
+            -- (or we hit the timeout ceiling).
+            _ <- waitForModel model expected
+            pass
+        )
     finalModel <- LVar.get model
-    expected <- runUnionFolderMutations folders
     finalModel `shouldBe` expected
-    print expected
   where
-    -- NOTE: These timings may not be enough on a slow system.
-    withPaddedThreadDelay :: (MonadUnliftIO m) => Int -> m () -> m ()
-    withPaddedThreadDelay padding action = do
-      -- Wait for the initial model to be loaded.
-      threadDelay padding
-      action
-      -- Wait for fsnotify to handle events
-      threadDelay padding
+    -- Brief delay to give fsnotify watchers time to come online before we
+    -- mutate files. fsnotify provides no synchronous readiness signal.
+    fsnotifyWatcherSetupDelay :: Int
+    fsnotifyWatcherSetupDelay = 200_000 -- 200ms
+
+    -- Wait (up to the timeout) until the LVar matches the expected value.
+    -- Returns True if matched, False if we timed out.
+    waitForModel ::
+      (MonadUnliftIO m, Eq a) =>
+      LVar.LVar a ->
+      a ->
+      m Bool
+    waitForModel lv target = go modelWaitTimeout
+      where
+        pollInterval = 10_000 -- 10ms
+        modelWaitTimeout = 5_000_000 -- 5s ceiling; fast path exits on first match
+        go remaining = do
+          v <- LVar.get lv
+          if v == target
+            then pure True
+            else
+              if remaining <= 0
+                then pure False
+                else do
+                  threadDelay pollInterval
+                  go (remaining - pollInterval)
 
 -- | Represent the mutation of a folder over time.
 --

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               unionmount
-version:            0.3.0.0
+version:            0.4.0.0
 license:            MIT
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -69,7 +69,10 @@ common library-common
 
 library
   import:          library-common
-  exposed-modules: System.UnionMount
+  exposed-modules:
+    System.UnionMount
+    System.UnionMount.Internal
+
   hs-source-dirs:  src
 
 test-suite test

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -82,6 +82,7 @@ test-suite test
     , hspec
     , monad-logger
     , monad-logger-extras
+    , QuickCheck
     , relude
 
   if flag(ghcid)
@@ -89,4 +90,7 @@ test-suite test
 
   else
     build-depends: unionmount
-    other-modules: System.UnionMountSpec
+    other-modules:
+      System.UnionMount.PropSpec
+      System.UnionMount.UnitSpec
+      System.UnionMountSpec


### PR DESCRIPTION
## Summary

- **Task 1 — polling instead of fixed delay:** `unionMountSpec` now polls the `LVar` (10 ms interval, 5 s ceiling) after mutating files, and uses a shorter 200 ms pre-mutate delay to let fsnotify watchers come online. Faster locally and less flaky on slow CI than the old fixed 500 ms pad on either side.
- **Task 2 — pure unit tests:** New `System.UnionMount.UnitSpec` covers `chainM`, `getTag` (relative match, miss, first-match-wins, absolute-path `**/` prefix), and the `OverlayFs` helpers (empty lookup, add, multi-source, remove leaves siblings, remove-last collapses to `Nothing`, remove of a non-existent source is a no-op). `OverlayFs`, its helpers, and `getTag` are now re-exported under the existing `-- For tests` section of `System.UnionMount`.
- **Task 3 — ignore + multi-tag:** `unionMountSpec` factored through `unionMountSpecWith` taking an ignore list, with a new case that drops `*.ignored` on both initial scan and fsnotify events. A focused `"unionMount tags"` case asserts that multi-tag patterns partition files correctly on the initial scan.
- **Task 4 — delete-shadowed-file:** New case where the top layer shadows a file from the lower layer, then the top copy is removed; the test asserts that the model transitions to the lower layer's content (exercising `overlayFsRemove` + `Refresh Existing`).
- **Task 5 — QuickCheck property:** New `System.UnionMount.PropSpec` generates random `FolderMutation` sequences (with safe removes and optional mount points) and asserts that the `unionMount` model equals the IO-materialized state. Bounded to 15 cases so fsnotify-driven runtime stays reasonable.

Before: 4 example tests, fixed 1 s fsnotify padding per case.
After: 22 examples, typical per-fsnotify-case wait ≈ 200 ms + a few poll ticks.

## Test plan

- [x] `cabal test test` — 22 examples, 0 failures, ~14 s total
- [x] `treefmt` clean