### PR TITLE
Per-source ignore patterns for unionMount

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,14 +1,16 @@
 
 ## Unreleased
 
-- Add per-source ignore patterns to `unionMount`. The new `Map source [FilePattern]` parameter scopes ignores to a single source, fixing the cross-source coupling where one layer's ignore list would silently hide matching files in other layers. **Breaking change** for `unionMount` callers; `mount` is unaffected. Migration:
+- Per-source ignore patterns for `unionMount`, replacing the prior flat `[FilePattern]` ignore list. The single `Map source [FilePattern]` parameter scopes ignores to the source they are keyed under, fixing the cross-source coupling where one layer's ignore list would silently hide matching files in sibling layers. To apply a pattern to every source ("universal" ignore), key it under every source — the per-source map can emulate the old global behavior, so the redundant flat list is gone. **Breaking change** for `unionMount` callers; `mount` is unaffected (it builds the singleton map internally). [#16](https://github.com/srid/unionmount/pull/16). Migration:
 
   ```diff
   -unionMount sources pats ignore         model0 handleAction
-  +unionMount sources pats ignore mempty  model0 handleAction
+  +unionMount sources pats perSourceIgnore model0 handleAction
   ```
 
-  Pass `mempty` for the new parameter to preserve prior behavior. Move any layer-specific patterns out of the global list and into `Map.singleton <source> [<patterns>]` to gain layer-scoped suppression.
+  - `perSourceIgnore = mempty` and dropping the old `ignore` argument preserves "no ignores at all".
+  - To match the prior global semantics: `perSourceIgnore = Map.fromSet (const ignore) (Set.map fst sources)`.
+  - To gain layer-scoped suppression: key each source's patterns separately.
 - Broaden test coverage; expose pure internals as `System.UnionMount.Internal` (#15)
 
 ## 0.3.0.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,14 @@
 
 ## Unreleased
 
-- Add per-source ignore patterns to `unionMount`. The new `Map source [FilePattern]` parameter scopes ignores to a single source, fixing the cross-source coupling where one layer's ignore list would silently hide matching files in other layers. Callers who only need universal ignores can pass an empty map. **Breaking change.**
+- Add per-source ignore patterns to `unionMount`. The new `Map source [FilePattern]` parameter scopes ignores to a single source, fixing the cross-source coupling where one layer's ignore list would silently hide matching files in other layers. **Breaking change** for `unionMount` callers; `mount` is unaffected. Migration:
+
+  ```diff
+  -unionMount sources pats ignore         model0 handleAction
+  +unionMount sources pats ignore mempty  model0 handleAction
+  ```
+
+  Pass `mempty` for the new parameter to preserve prior behavior. Move any layer-specific patterns out of the global list and into `Map.singleton <source> [<patterns>]` to gain layer-scoped suppression.
 - Broaden test coverage; expose pure internals as `System.UnionMount.Internal` (#15)
 
 ## 0.3.0.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 
 ## Unreleased
 
+- Add per-source ignore patterns to `unionMount`. The new `Map source [FilePattern]` parameter scopes ignores to a single source, fixing the cross-source coupling where one layer's ignore list would silently hide matching files in other layers. Callers who only need universal ignores can pass an empty map. **Breaking change.**
 - Broaden test coverage; expose pure internals as `System.UnionMount.Internal` (#15)
 
 ## 0.3.0.0

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -81,7 +81,7 @@ mount ::
 mount folder pats ignore var0 toAction' =
   let tag0 = ()
       sources = one (tag0, (folder, Nothing))
-   in unionMount sources pats ignore Map.empty var0 $ \ch -> do
+   in unionMount sources pats (Map.singleton tag0 ignore) var0 $ \ch -> do
         let fsSet = (fmap . fmap . fmap . fmap) void $ fmap Map.toList <$> Map.toList ch
         (\(tag, xs) -> uncurry (toAction' tag) `chainM` xs) `chainM` fsSet
   where
@@ -99,20 +99,12 @@ chainM f =
 
 -- | Union mount a set of sources (directories) into a model.
 --
--- Two ignore inputs are accepted:
---
--- * The flat @[FilePattern]@ list applies to every source. Use it for
---   universal patterns (e.g. dotfile directories, editor backup files) that
---   should never be visible to the model regardless of which layer they
---   live in.
---
--- * The @Map source [FilePattern]@ scopes patterns to a single source. A
---   pattern listed under source @A@ only suppresses files inside @A@ — it
---   does not affect files matching the same path inside any other source.
---   This is the right home for layer-private ignores (e.g. patterns loaded
---   from a per-layer ignore file).
---
--- For sources missing from the per-source map, only the global list applies.
+-- Ignore patterns are scoped to the source they are keyed under: a
+-- pattern listed for source @A@ only suppresses files inside @A@ and
+-- does not affect files matching the same path inside any other
+-- source. Sources absent from the map see no ignore patterns. To
+-- apply a pattern to every source (a "universal" ignore), key it
+-- under every source.
 unionMount ::
   forall source tag model m.
   ( MonadIO m,
@@ -123,22 +115,13 @@ unionMount ::
   ) =>
   Set (source, (FilePath, Maybe FilePath)) ->
   [(tag, FilePattern)] ->
-  -- | Global ignore patterns. Applied to every source. Reserve this for
-  -- patterns that genuinely apply to all sources (e.g. dotfile dirs,
-  -- editor backup files); anything layer-specific belongs in the
-  -- per-source map below.
-  [FilePattern] ->
-  -- | Per-source ignore patterns. The list keyed under source @s@ only
-  -- suppresses files inside @s@. Sources missing from the map see only
-  -- the global list. Patterns are merged with the global list, so
-  -- duplicating a global pattern here has no extra effect — keep each
-  -- pattern in exactly one of the two parameters to avoid confusion.
+  -- | Per-source ignore patterns.
   Map source [FilePattern] ->
   model ->
   (Change source tag -> m (model -> model)) ->
   m (model, (model -> m ()) -> m ())
-unionMount sources pats ignore perSourceIgnore model0 handleAction = do
-  (x0, xf) <- unionMount' sources pats ignore perSourceIgnore
+unionMount sources pats perSourceIgnore model0 handleAction = do
+  (x0, xf) <- unionMount' sources pats perSourceIgnore
   x0' <- interceptExceptions id $ handleAction x0
   let initial = x0' model0
   lvar <- LVar.new initial
@@ -149,7 +132,7 @@ unionMount sources pats ignore perSourceIgnore model0 handleAction = do
           x <- LVar.get lvar
           send x
         log LevelInfo "Remounting..."
-        (a, b) <- unionMount sources pats ignore perSourceIgnore model0 handleAction
+        (a, b) <- unionMount sources pats perSourceIgnore model0 handleAction
         send a
         b send
   pure (x0' model0, sender)
@@ -192,14 +175,13 @@ unionMount' ::
   ) =>
   Set (source, (FilePath, Maybe FilePath)) ->
   [(tag, FilePattern)] ->
-  [FilePattern] ->
   Map source [FilePattern] ->
   m1
     ( Change source tag,
       (Change source tag -> m ()) ->
       m Cmd
     )
-unionMount' sources pats ignore perSourceIgnore = do
+unionMount' sources pats perSourceIgnore = do
   flip evalStateT (emptyOverlayFs @source) $ do
     -- Initial traversal of sources
     changes0 :: Change source tag <-
@@ -252,7 +234,7 @@ unionMount' sources pats ignore perSourceIgnore = do
       )
   where
     ignoreFor :: source -> [FilePattern]
-    ignoreFor src = ignore <> Map.findWithDefault [] src perSourceIgnore
+    ignoreFor src = Map.findWithDefault [] src perSourceIgnore
 
 filesMatching :: (MonadIO m, MonadLogger m) => FilePath -> [FilePattern] -> [FilePattern] -> m [FilePath]
 filesMatching parent' pats ignore = do

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -81,7 +81,7 @@ mount ::
 mount folder pats ignore var0 toAction' =
   let tag0 = ()
       sources = one (tag0, (folder, Nothing))
-   in unionMount sources pats ignore var0 $ \ch -> do
+   in unionMount sources pats ignore Map.empty var0 $ \ch -> do
         let fsSet = (fmap . fmap . fmap . fmap) void $ fmap Map.toList <$> Map.toList ch
         (\(tag, xs) -> uncurry (toAction' tag) `chainM` xs) `chainM` fsSet
   where
@@ -98,6 +98,21 @@ chainM f =
     chain = flip $ foldl' $ flip ($)
 
 -- | Union mount a set of sources (directories) into a model.
+--
+-- Two ignore inputs are accepted:
+--
+-- * The flat @[FilePattern]@ list applies to every source. Use it for
+--   universal patterns (e.g. dotfile directories, editor backup files) that
+--   should never be visible to the model regardless of which layer they
+--   live in.
+--
+-- * The @Map source [FilePattern]@ scopes patterns to a single source. A
+--   pattern listed under source @A@ only suppresses files inside @A@ — it
+--   does not affect files matching the same path inside any other source.
+--   This is the right home for layer-private ignores (e.g. patterns loaded
+--   from a per-layer ignore file).
+--
+-- For sources missing from the per-source map, only the global list applies.
 unionMount ::
   forall source tag model m.
   ( MonadIO m,
@@ -108,12 +123,16 @@ unionMount ::
   ) =>
   Set (source, (FilePath, Maybe FilePath)) ->
   [(tag, FilePattern)] ->
+  -- | Global ignore patterns (applied to every source).
   [FilePattern] ->
+  -- | Per-source ignore patterns (applied only to the source they are keyed
+  -- under).
+  Map source [FilePattern] ->
   model ->
   (Change source tag -> m (model -> model)) ->
   m (model, (model -> m ()) -> m ())
-unionMount sources pats ignore model0 handleAction = do
-  (x0, xf) <- unionMount' sources pats ignore
+unionMount sources pats ignore perSourceIgnore model0 handleAction = do
+  (x0, xf) <- unionMount' sources pats ignore perSourceIgnore
   x0' <- interceptExceptions id $ handleAction x0
   let initial = x0' model0
   lvar <- LVar.new initial
@@ -124,7 +143,7 @@ unionMount sources pats ignore model0 handleAction = do
           x <- LVar.get lvar
           send x
         log LevelInfo "Remounting..."
-        (a, b) <- unionMount sources pats ignore model0 handleAction
+        (a, b) <- unionMount sources pats ignore perSourceIgnore model0 handleAction
         send a
         b send
   pure (x0' model0, sender)
@@ -168,18 +187,19 @@ unionMount' ::
   Set (source, (FilePath, Maybe FilePath)) ->
   [(tag, FilePattern)] ->
   [FilePattern] ->
+  Map source [FilePattern] ->
   m1
     ( Change source tag,
       (Change source tag -> m ()) ->
       m Cmd
     )
-unionMount' sources pats ignore = do
+unionMount' sources pats ignore perSourceIgnore = do
   flip evalStateT (emptyOverlayFs @source) $ do
     -- Initial traversal of sources
     changes0 :: Change source tag <-
       fmap snd . flip runStateT Map.empty $ do
         forM_ sources $ \(src, (folder, mountPoint)) -> do
-          taggedFiles <- filesMatchingWithTag folder pats ignore
+          taggedFiles <- filesMatchingWithTag folder pats (ignoreFor src)
           forM_ taggedFiles $ \(tag, fs) -> do
             forM_ fs $ \fp -> do
               put =<< lift . changeInsert src tag mountPoint fp (Refresh Existing ()) =<< get
@@ -202,7 +222,7 @@ unionMount' sources pats ignore = do
                       =<< atomically (tryTakeTMVar q)
                   loop = do
                     (src, mountPoint, fp, actE) <- readDebounced
-                    let shouldIgnore = any (?== fp) ignore
+                    let shouldIgnore = any (?== fp) (ignoreFor src)
                     case actE of
                       Left _ -> do
                         let reason = "Unhandled folder event on '" <> toText fp <> "'"
@@ -224,6 +244,9 @@ unionMount' sources pats ignore = do
                             loop
                in evalStateT loop ofs
       )
+  where
+    ignoreFor :: source -> [FilePattern]
+    ignoreFor src = ignore <> Map.findWithDefault [] src perSourceIgnore
 
 filesMatching :: (MonadIO m, MonadLogger m) => FilePath -> [FilePattern] -> [FilePattern] -> m [FilePath]
 filesMatching parent' pats ignore = do

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -123,10 +123,16 @@ unionMount ::
   ) =>
   Set (source, (FilePath, Maybe FilePath)) ->
   [(tag, FilePattern)] ->
-  -- | Global ignore patterns (applied to every source).
+  -- | Global ignore patterns. Applied to every source. Reserve this for
+  -- patterns that genuinely apply to all sources (e.g. dotfile dirs,
+  -- editor backup files); anything layer-specific belongs in the
+  -- per-source map below.
   [FilePattern] ->
-  -- | Per-source ignore patterns (applied only to the source they are keyed
-  -- under).
+  -- | Per-source ignore patterns. The list keyed under source @s@ only
+  -- suppresses files inside @s@. Sources missing from the map see only
+  -- the global list. Patterns are merged with the global list, so
+  -- duplicating a global pattern here has no extra effect — keep each
+  -- pattern in exactly one of the two parameters to avoid confusion.
   Map source [FilePattern] ->
   model ->
   (Change source tag -> m (model -> model)) ->

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -180,6 +180,78 @@ spec = do
           -- to the union entry. A's public.txt is unaffected.
           Map.lookup "secret.txt" model0 `shouldBe` Just ["B"]
           Map.lookup "public.txt" model0 `shouldBe` Just ["A"]
+    it "per-source ignore patterns also gate live fsnotify events" $ do
+      -- Same shape as above, but the ignored file is created *after* the
+      -- mount is live, exercising the fsnotify loop's ignoreFor check
+      -- rather than the initial directory scan.
+      withSystemTempDirectory "perSourceLiveA" $ \dirA ->
+        withSystemTempDirectory "perSourceLiveB" $ \dirB -> do
+          let layers =
+                Set.fromList
+                  [ ("A" :: String, (dirA, Nothing)),
+                    ("B", (dirB, Nothing))
+                  ]
+              pats = [((), "*.txt")]
+              perSource = Map.singleton "A" ["secret.txt"]
+              fold0 :: UM.Change String () -> Map FilePath [String] -> Map FilePath [String]
+              fold0 ch m0 =
+                Map.foldrWithKey
+                  ( \_tag files acc ->
+                      Map.foldrWithKey
+                        ( \fp act ->
+                            case act of
+                              UM.Refresh _ srcs ->
+                                Map.insert fp (NE.toList $ fst <$> srcs)
+                              UM.Delete -> Map.delete fp
+                        )
+                        acc
+                        files
+                  )
+                  m0
+                  ch
+          model <- LVar.empty
+          flip runLoggerLoggingT logToNowhere $ do
+            (model0, patch) <-
+              UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $
+                \change -> pure $ fold0 change
+            LVar.set model model0
+            race_
+              (patch $ LVar.set model)
+              ( do
+                  -- Give fsnotify time to attach watches before mutating.
+                  threadDelay 200_000
+                  writeFile (dirA </> "secret.txt") "from A (live)"
+                  writeFile (dirA </> "public.txt") "A is public (live)"
+                  writeFile (dirB </> "secret.txt") "from B (live)"
+                  let target =
+                        Map.fromList
+                          [ ("secret.txt", ["B"]),
+                            ("public.txt", ["A"])
+                          ]
+                  _ <- waitForExact model target
+                  pass
+              )
+          finalModel <- LVar.get model
+          Map.lookup "secret.txt" finalModel `shouldBe` Just ["B"]
+          Map.lookup "public.txt" finalModel `shouldBe` Just ["A"]
+  where
+    waitForExact ::
+      (MonadUnliftIO m) =>
+      LVar.LVar (Map FilePath [String]) ->
+      Map FilePath [String] ->
+      m Bool
+    waitForExact lv target = go (5_000_000 :: Int)
+      where
+        go remaining = do
+          v <- LVar.get lv
+          if v == target
+            then pure True
+            else
+              if remaining <= 0
+                then pure False
+                else do
+                  threadDelay 10_000
+                  go (remaining - 10_000)
 
 -- | Test `UM.unionMount` on a set of folders whose contents/mutations are
 -- represented by a `FolderMutation`, and check that the resulting model is

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -145,8 +145,6 @@ spec = do
               ("txt", Set.singleton "b.txt")
             ]
     it "per-source ignore patterns are scoped to their source" $ do
-      -- Two sibling sources each contain a "secret.txt". An ignore pattern
-      -- keyed under source A must hide A's copy without hiding B's copy.
       withSystemTempDirectory "perSourceA" $ \dirA ->
         withSystemTempDirectory "perSourceB" $ \dirB -> do
           writeFile (dirA </> "secret.txt") "from A"
@@ -162,8 +160,6 @@ spec = do
           (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
             UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $ \change ->
               pure $ foldChangeBySource change
-          -- A's secret.txt is hidden; B's secret.txt is the only contributor
-          -- to the union entry. A's public.txt is unaffected.
           Map.lookup "secret.txt" model0 `shouldBe` Just ["B"]
           Map.lookup "public.txt" model0 `shouldBe` Just ["A"]
     it "per-source ignore patterns also gate live fsnotify events" $ do

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -133,7 +133,7 @@ spec = do
         let layers = Set.singleton (dir :: FilePath, (dir, Nothing))
             pats = [("md" :: String, "*.md"), ("txt", "*.txt")]
         (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
-          UM.unionMount layers pats [] (mempty :: Map String (Set FilePath)) $ \change ->
+          UM.unionMount layers pats [] mempty (mempty :: Map String (Set FilePath)) $ \change ->
             pure $ \m0 ->
               Map.foldrWithKey
                 (\tag files -> Map.insertWith Set.union tag (Map.keysSet files))
@@ -144,6 +144,42 @@ spec = do
             [ ("md", Set.singleton "a.md"),
               ("txt", Set.singleton "b.txt")
             ]
+    it "per-source ignore patterns are scoped to their source" $ do
+      -- Two sibling sources each contain a "secret.txt". An ignore pattern
+      -- keyed under source A must hide A's copy without hiding B's copy.
+      withSystemTempDirectory "perSourceA" $ \dirA ->
+        withSystemTempDirectory "perSourceB" $ \dirB -> do
+          writeFile (dirA </> "secret.txt") "from A"
+          writeFile (dirA </> "public.txt") "A is public"
+          writeFile (dirB </> "secret.txt") "from B"
+          let layers =
+                Set.fromList
+                  [ ("A" :: String, (dirA, Nothing)),
+                    ("B", (dirB, Nothing))
+                  ]
+              pats = [((), "*.txt")]
+              perSource = Map.singleton "A" ["secret.txt"]
+          (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
+            UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $ \change ->
+              pure $ \m0 ->
+                Map.foldrWithKey
+                  ( \_tag files acc ->
+                      Map.foldrWithKey
+                        ( \fp act ->
+                            case act of
+                              UM.Refresh _ srcs ->
+                                Map.insert fp (NE.toList $ fst <$> srcs)
+                              UM.Delete -> Map.delete fp
+                        )
+                        acc
+                        files
+                  )
+                  m0
+                  change
+          -- A's secret.txt is hidden; B's secret.txt is the only contributor
+          -- to the union entry. A's public.txt is unaffected.
+          Map.lookup "secret.txt" model0 `shouldBe` Just ["B"]
+          Map.lookup "public.txt" model0 `shouldBe` Just ["A"]
 
 -- | Test `UM.unionMount` on a set of folders whose contents/mutations are
 -- represented by a `FolderMutation`, and check that the resulting model is
@@ -170,7 +206,7 @@ unionMountSpecWith ignore folders = do
     model <- LVar.empty
     flip runLoggerLoggingT logToNowhere $ do
       let layers = Set.fromList $ toList tempDirs <&> \(folder, path) -> (path, (path, _folderMountPoint folder))
-      (model0, patch) <- UM.unionMount layers allFiles ignore mempty $ \change -> do
+      (model0, patch) <- UM.unionMount layers allFiles ignore mempty mempty $ \change -> do
         let files = Unsafe.fromJust $ Map.lookup () change
         flip UM.chainM (Map.toList files) $ \(fp, act) -> do
           case act of

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -161,21 +161,7 @@ spec = do
               perSource = Map.singleton "A" ["secret.txt"]
           (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
             UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $ \change ->
-              pure $ \m0 ->
-                Map.foldrWithKey
-                  ( \_tag files acc ->
-                      Map.foldrWithKey
-                        ( \fp act ->
-                            case act of
-                              UM.Refresh _ srcs ->
-                                Map.insert fp (NE.toList $ fst <$> srcs)
-                              UM.Delete -> Map.delete fp
-                        )
-                        acc
-                        files
-                  )
-                  m0
-                  change
+              pure $ foldChangeBySource change
           -- A's secret.txt is hidden; B's secret.txt is the only contributor
           -- to the union entry. A's public.txt is unaffected.
           Map.lookup "secret.txt" model0 `shouldBe` Just ["B"]
@@ -193,27 +179,11 @@ spec = do
                   ]
               pats = [((), "*.txt")]
               perSource = Map.singleton "A" ["secret.txt"]
-              fold0 :: UM.Change String () -> Map FilePath [String] -> Map FilePath [String]
-              fold0 ch m0 =
-                Map.foldrWithKey
-                  ( \_tag files acc ->
-                      Map.foldrWithKey
-                        ( \fp act ->
-                            case act of
-                              UM.Refresh _ srcs ->
-                                Map.insert fp (NE.toList $ fst <$> srcs)
-                              UM.Delete -> Map.delete fp
-                        )
-                        acc
-                        files
-                  )
-                  m0
-                  ch
           model <- LVar.empty
           flip runLoggerLoggingT logToNowhere $ do
             (model0, patch) <-
               UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $
-                \change -> pure $ fold0 change
+                \change -> pure $ foldChangeBySource change
             LVar.set model model0
             race_
               (patch $ LVar.set model)
@@ -284,6 +254,31 @@ unionMountSpecWith ignore folders = do
         )
     finalModel <- LVar.get model
     finalModel `shouldBe` expected
+
+-- | Project a `UM.Change source ()` into a flat `Map FilePath [source]`
+-- — one entry per resulting filepath, listing the sources that contribute
+-- to it. Used by the per-source-ignore tests to assert which layers a
+-- given path is sourced from after the mount converges.
+foldChangeBySource ::
+  (Ord source) =>
+  UM.Change source () ->
+  Map FilePath [source] ->
+  Map FilePath [source]
+foldChangeBySource ch m0 =
+  Map.foldrWithKey
+    ( \_tag files acc ->
+        Map.foldrWithKey
+          ( \fp act ->
+              case act of
+                UM.Refresh _ srcs ->
+                  Map.insert fp (NE.toList $ fst <$> srcs)
+                UM.Delete -> Map.delete fp
+          )
+          acc
+          files
+    )
+    m0
+    ch
 
 -- | Brief delay to give fsnotify watchers time to come online before we
 -- mutate files. fsnotify provides no synchronous readiness signal.

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -133,7 +133,7 @@ spec = do
         let layers = Set.singleton (dir :: FilePath, (dir, Nothing))
             pats = [("md" :: String, "*.md"), ("txt", "*.txt")]
         (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
-          UM.unionMount layers pats [] mempty (mempty :: Map String (Set FilePath)) $ \change ->
+          UM.unionMount layers pats mempty (mempty :: Map String (Set FilePath)) $ \change ->
             pure $ \m0 ->
               Map.foldrWithKey
                 (\tag files -> Map.insertWith Set.union tag (Map.keysSet files))
@@ -158,7 +158,7 @@ spec = do
               pats = [((), "*.txt")]
               perSource = Map.singleton "A" ["secret.txt"]
           (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
-            UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $ \change ->
+            UM.unionMount layers pats perSource (mempty :: Map FilePath [String]) $ \change ->
               pure $ foldChangeBySource change
           Map.lookup "secret.txt" model0 `shouldBe` Just ["B"]
           Map.lookup "public.txt" model0 `shouldBe` Just ["A"]
@@ -178,7 +178,7 @@ spec = do
           model <- LVar.empty
           flip runLoggerLoggingT logToNowhere $ do
             (model0, patch) <-
-              UM.unionMount layers pats [] perSource (mempty :: Map FilePath [String]) $
+              UM.unionMount layers pats perSource (mempty :: Map FilePath [String]) $
                 \change -> pure $ foldChangeBySource change
             LVar.set model model0
             race_
@@ -225,7 +225,8 @@ unionMountSpecWith ignore folders = do
     model <- LVar.empty
     flip runLoggerLoggingT logToNowhere $ do
       let layers = Set.fromList $ toList tempDirs <&> \(folder, path) -> (path, (path, _folderMountPoint folder))
-      (model0, patch) <- UM.unionMount layers allFiles ignore mempty mempty $ \change -> do
+          perSourceIgnore = Map.fromSet (const ignore) (Set.map fst layers)
+      (model0, patch) <- UM.unionMount layers allFiles perSourceIgnore mempty $ \change -> do
         let files = Unsafe.fromJust $ Map.lookup () change
         flip UM.chainM (Map.toList files) $ \(fp, act) -> do
           case act of

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -218,8 +218,7 @@ spec = do
             race_
               (patch $ LVar.set model)
               ( do
-                  -- Give fsnotify time to attach watches before mutating.
-                  threadDelay 200_000
+                  threadDelay fsnotifyWatcherSetupDelay
                   writeFile (dirA </> "secret.txt") "from A (live)"
                   writeFile (dirA </> "public.txt") "A is public (live)"
                   writeFile (dirB </> "secret.txt") "from B (live)"
@@ -228,30 +227,12 @@ spec = do
                           [ ("secret.txt", ["B"]),
                             ("public.txt", ["A"])
                           ]
-                  _ <- waitForExact model target
+                  _ <- waitForModel model target
                   pass
               )
           finalModel <- LVar.get model
           Map.lookup "secret.txt" finalModel `shouldBe` Just ["B"]
           Map.lookup "public.txt" finalModel `shouldBe` Just ["A"]
-  where
-    waitForExact ::
-      (MonadUnliftIO m) =>
-      LVar.LVar (Map FilePath [String]) ->
-      Map FilePath [String] ->
-      m Bool
-    waitForExact lv target = go (5_000_000 :: Int)
-      where
-        go remaining = do
-          v <- LVar.get lv
-          if v == target
-            then pure True
-            else
-              if remaining <= 0
-                then pure False
-                else do
-                  threadDelay 10_000
-                  go (remaining - 10_000)
 
 -- | Test `UM.unionMount` on a set of folders whose contents/mutations are
 -- represented by a `FolderMutation`, and check that the resulting model is
@@ -303,33 +284,33 @@ unionMountSpecWith ignore folders = do
         )
     finalModel <- LVar.get model
     finalModel `shouldBe` expected
-  where
-    -- Brief delay to give fsnotify watchers time to come online before we
-    -- mutate files. fsnotify provides no synchronous readiness signal.
-    fsnotifyWatcherSetupDelay :: Int
-    fsnotifyWatcherSetupDelay = 200_000 -- 200ms
 
-    -- Wait (up to the timeout) until the LVar matches the expected value.
-    -- Returns True if matched, False if we timed out.
-    waitForModel ::
-      (MonadUnliftIO m, Eq a) =>
-      LVar.LVar a ->
-      a ->
-      m Bool
-    waitForModel lv target = go modelWaitTimeout
-      where
-        pollInterval = 10_000 -- 10ms
-        modelWaitTimeout = 5_000_000 -- 5s ceiling; fast path exits on first match
-        go remaining = do
-          v <- LVar.get lv
-          if v == target
-            then pure True
-            else
-              if remaining <= 0
-                then pure False
-                else do
-                  threadDelay pollInterval
-                  go (remaining - pollInterval)
+-- | Brief delay to give fsnotify watchers time to come online before we
+-- mutate files. fsnotify provides no synchronous readiness signal.
+fsnotifyWatcherSetupDelay :: Int
+fsnotifyWatcherSetupDelay = 200_000 -- 200ms
+
+-- | Wait (up to the timeout) until the LVar matches the expected value.
+-- Returns True if matched, False if we timed out.
+waitForModel ::
+  (MonadUnliftIO m, Eq a) =>
+  LVar.LVar a ->
+  a ->
+  m Bool
+waitForModel lv target = go modelWaitTimeout
+  where
+    pollInterval = 10_000 -- 10ms
+    modelWaitTimeout = 5_000_000 -- 5s ceiling; fast path exits on first match
+    go remaining = do
+      v <- LVar.get lv
+      if v == target
+        then pure True
+        else
+          if remaining <= 0
+            then pure False
+            else do
+              threadDelay pollInterval
+              go (remaining - pollInterval)
 
 -- | Represent the mutation of a folder over time.
 --


### PR DESCRIPTION
**`unionMount` now scopes ignore patterns to the source they're keyed under** (`Map source [FilePattern]`). The flat global `[FilePattern]` list is gone — per-source can emulate it by keying the same patterns under every source — so the API is one ignore parameter, not two. This fixes the cross-source coupling in the prior matcher where one layer's ignore list would silently hide files in sibling layers, which `Emanote` (and any union-mount consumer) needs to surface user-controllable ignore files like `.emanoteignore`. See [srid/emanote#228](https://github.com/srid/emanote/issues/228) for the downstream motivation.

### What changed in the API

```haskell
unionMount ::
  ...
  Set (source, (FilePath, Maybe FilePath)) ->
  [(tag, FilePattern)] ->
  Map source [FilePattern] ->     -- per-source ignores (only)
  model ->
  (Change source tag -> m (model -> model)) ->
  m (model, (model -> m ()) -> m ())
```

| Use case | Pattern shape |
| --- | --- |
| Ignore `secret.md` only inside layer A | `Map.singleton "A" ["secret.md"]` |
| Ignore dotfile dirs across every layer | `Map.fromSet (const ["**/.*/**"]) sourceKeys` |
| No ignores at all | `mempty` |

`mount` is unaffected at the API surface — it still takes a flat `[FilePattern]` and folds it into a singleton map internally.

### How it works

Both ignore consultation sites — initial traversal in `filesMatchingWithTag` and the live fsnotify loop's `shouldIgnore` check — go through `ignoreFor src = Map.findWithDefault [] src perSourceIgnore`. Sources missing from the map see no ignores; the matcher always knows which source it's deciding for.

### Test coverage

Two new specs:
- A static-scan test creating two sibling sources each containing `secret.txt`, with per-source ignore keyed under source A — A's copy is hidden, B's stays.
- A live-fsnotify test that creates the file _after_ mount, exercising the runtime `ignoreFor src` path rather than the initial directory scan.

> **Breaking change.** `unionMount` callers need to swap their flat ignore list for a `Map source [FilePattern]`. See `ChangeLog.md` for the mechanical migration. `mount` callers are unaffected.

### Try it locally

```sh
nix build github:srid/unionmount/per-source-ignore
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._