### PR TITLE
Add unionMountStreaming: handler reads + folds the running model

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 
 ## Unreleased
 
+- Add `unionMountStreaming`: a variant of `unionMount` whose handler is `Change source tag -> model -> m model` instead of `Change source tag -> m (model -> model)`. Two new capabilities fall out of the shape: (1) the handler can fold per-file updates through the running model so each file's closure is GC'd as soon as its update has been applied — important for downstream consumers that load very large directories on the initial mount; (2) the handler can read the current model when computing each step, removing the need for consumers to maintain a parallel mirror just to look at existing state inside the change handler. Existing `unionMount` is unchanged.
 - Per-source ignore patterns for `unionMount`, replacing the prior flat `[FilePattern]` ignore list. The single `Map source [FilePattern]` parameter scopes ignores to the source they are keyed under, fixing the cross-source coupling where one layer's ignore list would silently hide matching files in sibling layers. To apply a pattern to every source ("universal" ignore), key it under every source — the per-source map can emulate the old global behavior, so the redundant flat list is gone. **Breaking change** for `unionMount` callers; `mount` is unaffected (it builds the singleton map internally). [#16](https://github.com/srid/unionmount/pull/16). Migration:
 
   ```diff

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -121,22 +121,14 @@ unionMount ::
   model ->
   (Change source tag -> m (model -> model)) ->
   m (model, (model -> m ()) -> m ())
-unionMount sources pats perSourceIgnore model0 handleAction = do
-  (x0, xf) <- unionMount' sources pats perSourceIgnore
-  x0' <- interceptExceptions id $ handleAction x0
-  let initial = x0' model0
-  lvar <- LVar.new initial
-  let sender send = do
-        Cmd_Remount <- xf $ \change -> do
-          change' <- interceptExceptions id $ handleAction change
-          LVar.modify lvar change'
-          x <- LVar.get lvar
-          send x
-        log LevelInfo "Remounting..."
-        (a, b) <- unionMount sources pats perSourceIgnore model0 handleAction
-        send a
-        b send
-  pure (x0' model0, sender)
+unionMount sources pats perSourceIgnore model0 handleAction =
+  -- A 'Change -> m (model -> model)' handler is the lazy variant of
+  -- a 'Change -> model -> m model' handler. Adapt and delegate, so
+  -- there is exactly one place that owns the LVar fold and the
+  -- remount loop.
+  unionMountStreaming sources pats perSourceIgnore model0 $ \change m -> do
+    f <- handleAction change
+    pure (f m)
 
 -- | Streaming variant of 'unionMount' whose handler reads the current model.
 --

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -24,7 +24,6 @@ import Control.Monad.Logger
     MonadLogger,
     logWithoutLoc,
   )
-import Data.LVar qualified as LVar
 import Data.Map.Strict qualified as Map
 import System.Directory (canonicalizePath)
 import System.FSNotify
@@ -51,6 +50,7 @@ import System.UnionMount.Internal
     overlayFsRemove,
   )
 import UnliftIO (MonadUnliftIO, finally, race, try, withRunInIO)
+import UnliftIO.MVar (modifyMVar)
 
 -- | Simplified version of `unionMount` with exactly one layer.
 mount ::
@@ -189,12 +189,19 @@ unionMountStreaming ::
 unionMountStreaming sources pats perSourceIgnore model0 handleAction = do
   (x0, xf) <- unionMount' sources pats perSourceIgnore
   initial <- interceptExceptions model0 $ handleAction x0 model0
-  lvar <- LVar.new initial
+  -- 'MVar' (with 'modifyMVar') makes the get → handler → set
+  -- transition structurally atomic and exception-safe: a throw inside
+  -- the handler restores the slot to the prior value via 'modifyMVar's
+  -- 'bracket', and a concurrent take blocks rather than racing.
+  -- 'IORef' would force the handler to live outside the atomic
+  -- combinator (it accepts only pure @a -> (a, b)@), so 'MVar' is
+  -- the fit. Resolves #18.
+  mvar <- newMVar initial
   let sender send = do
         Cmd_Remount <- xf $ \change -> do
-          old <- LVar.get lvar
-          new <- interceptExceptions old $ handleAction change old
-          LVar.set lvar new
+          new <- modifyMVar mvar $ \old -> do
+            new <- interceptExceptions old $ handleAction change old
+            pure (new, new)
           send new
         log LevelInfo "Remounting..."
         (a, b) <- unionMountStreaming sources pats perSourceIgnore model0 handleAction

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -5,6 +5,7 @@ module System.UnionMount
   ( -- * Mount endpoints
     mount,
     unionMount,
+    unionMountStreaming,
     unionMount',
 
     -- * Types
@@ -136,6 +137,78 @@ unionMount sources pats perSourceIgnore model0 handleAction = do
         send a
         b send
   pure (x0' model0, sender)
+
+-- | Streaming variant of 'unionMount' whose handler reads the current model.
+--
+-- 'unionMount' takes a handler of shape @Change -> m (model -> model)@:
+-- the handler returns a transformer that the library applies to the
+-- running model. Two consequences fall out of that shape and motivate
+-- this variant.
+--
+-- * On a multi-thousand-file initial mount the whole batch's worth of
+--  per-file closures (and whatever they capture, e.g. parsed Pandoc
+--  trees) stays alive until the final fold runs — pinning peak memory
+--  on the order of the entire batch.
+-- * The handler cannot read the running model when it computes the
+--  transformer. A consumer that needs to see the existing state to
+--  decide what to do with a change (e.g. resolve a reverse-dependency
+--  index for a hot-reload) has to maintain a mirror outside the
+--  library.
+--
+-- 'unionMountStreaming' addresses both. The handler is
+-- @Change -> model -> m model@: the library hands it the current model
+-- and expects the next one. The consumer can fold per-file updates
+-- through the model one at a time (so each closure is GC'd as soon as
+-- its update has been applied) and read the running state directly when
+-- deciding how to react.
+--
+-- Caller-side, the typical fold pattern is:
+--
+-- @
+-- \\change m -> foldlM step m (changeToList change)
+--  where step m c = do { f <- perFileHandler c m; pure $! f m }
+-- @
+--
+-- The streaming benefit (memory) is realised on the initial batch
+-- (motivates @srid/emanote#66@). fsnotify-driven incremental updates use
+-- the same handler; those paths only ever supply one file's change at a
+-- time, so streaming is a no-op for them — but the read-current-model
+-- capability still applies and is the lever downstream consumers reach
+-- for during incremental updates (see @srid/emanote#263@'s Lua-filter
+-- hot-reload reverse-index lookup).
+--
+-- Ignore patterns follow the same per-source contract as 'unionMount';
+-- see that function's haddock.
+unionMountStreaming ::
+  forall source tag model m.
+  ( MonadIO m,
+    MonadUnliftIO m,
+    MonadLogger m,
+    Ord source,
+    Ord tag
+  ) =>
+  Set (source, (FilePath, Maybe FilePath)) ->
+  [(tag, FilePattern)] ->
+  -- | Per-source ignore patterns.
+  Map source [FilePattern] ->
+  model ->
+  (Change source tag -> model -> m model) ->
+  m (model, (model -> m ()) -> m ())
+unionMountStreaming sources pats perSourceIgnore model0 handleAction = do
+  (x0, xf) <- unionMount' sources pats perSourceIgnore
+  initial <- interceptExceptions model0 $ handleAction x0 model0
+  lvar <- LVar.new initial
+  let sender send = do
+        Cmd_Remount <- xf $ \change -> do
+          old <- LVar.get lvar
+          new <- interceptExceptions old $ handleAction change old
+          LVar.set lvar new
+          send new
+        log LevelInfo "Remounting..."
+        (a, b) <- unionMountStreaming sources pats perSourceIgnore model0 handleAction
+        send a
+        b send
+  pure (initial, sender)
 
 -- Log and ignore exceptions
 --

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -199,6 +199,65 @@ spec = do
           finalModel <- LVar.get model
           Map.lookup "secret.txt" finalModel `shouldBe` Just ["B"]
           Map.lookup "public.txt" finalModel `shouldBe` Just ["A"]
+  describe "unionMountStreaming" $ do
+    it "handler observes the running model when folding the initial batch" $ do
+      -- Three files; handler reads the model size *before* applying its own
+      -- update for each file. Across the batch the handler should observe
+      -- sizes {0, 1, 2} — the pre-step states as files are folded one at
+      -- a time. This is the read-current-model capability that the
+      -- streaming variant exists to provide.
+      withSystemTempDirectory "streamingObserve" $ \dir -> do
+        writeFile (dir </> "a.txt") "a"
+        writeFile (dir </> "b.txt") "b"
+        writeFile (dir </> "c.txt") "c"
+        observed <- newIORef Set.empty
+        let layers = Set.singleton (dir :: FilePath, (dir, Nothing))
+            pats = [((), "*.txt")]
+        (model0, _patch) <- flip runLoggerLoggingT logToNowhere $
+          UM.unionMountStreaming layers pats mempty (mempty :: Set FilePath) $ \change m0 ->
+            foldlM
+              ( \m (fp, _act) -> do
+                  liftIO $ atomicModifyIORef' observed $ \s -> (Set.insert (Set.size m) s, ())
+                  pure $ Set.insert fp m
+              )
+              m0
+              (Map.toList $ Unsafe.fromJust $ Map.lookup () change)
+        seen <- readIORef observed
+        seen `shouldBe` Set.fromList [0, 1, 2]
+        model0 `shouldBe` Set.fromList ["a.txt", "b.txt", "c.txt"]
+    it "fsnotify-driven update sees the prior model state" $ do
+      -- Pre-existing file A is in the model. User creates file B at runtime.
+      -- When the streaming handler fires for B, it must see A already in
+      -- the model — that's the hot-reload reverse-index lookup pattern.
+      withSystemTempDirectory "streamingLive" $ \dir -> do
+        writeFile (dir </> "a.txt") "a"
+        sawAOnB <- newIORef False
+        model <- LVar.empty
+        let layers = Set.singleton (dir :: FilePath, (dir, Nothing))
+            pats = [((), "*.txt")]
+        flip runLoggerLoggingT logToNowhere $ do
+          (model0, patch) <-
+            UM.unionMountStreaming layers pats mempty (mempty :: Set FilePath) $ \change m0 ->
+              foldlM
+                ( \m (fp, _act) -> do
+                    when (fp == "b.txt" && Set.member "a.txt" m) $
+                      liftIO $
+                        atomicModifyIORef' sawAOnB $
+                          \_ -> (True, ())
+                    pure $ Set.insert fp m
+                )
+                m0
+                (Map.toList $ Unsafe.fromJust $ Map.lookup () change)
+          LVar.set model model0
+          race_
+            (patch $ LVar.set model)
+            ( do
+                threadDelay fsnotifyWatcherSetupDelay
+                writeFile (dir </> "b.txt") "b"
+                _ <- waitForModel model (Set.fromList ["a.txt", "b.txt"])
+                pass
+            )
+        liftIO (readIORef sawAOnB) `shouldReturn` True
 
 -- | Test `UM.unionMount` on a set of folders whose contents/mutations are
 -- represented by a `FolderMutation`, and check that the resulting model is

--- a/unionmount.cabal
+++ b/unionmount.cabal
@@ -26,23 +26,17 @@ flag ghcid
 
 common library-common
   build-depends:
-    , async
     , base          >=4.13.0 && <5
-    , bytestring
     , containers
-    , data-default
     , directory
     , filepath
     , filepattern
     , fsnotify      >=0.4.0  && <0.5
-    , lvar
     , monad-logger
     , mtl
     , relude
     , text
-    , time
     , unliftio
-    , with-utf8
 
   mixins:
     base hiding (Prelude),
@@ -81,8 +75,10 @@ test-suite test
   hs-source-dirs: test
   main-is:        Spec.hs
   build-depends:
+    , bytestring
     , dir-traverse
     , hspec
+    , lvar
     , monad-logger
     , monad-logger-extras
     , QuickCheck


### PR DESCRIPTION
## Why

`unionMount`'s handler is `Change source tag -> m (model -> model)` — it returns a transformer that the library applies to the running model. Two real downstream pains have come from that shape.

### Pain 1: peak memory on the initial mount

For consumers that load many files at startup (Emanote at ~4500 notes pins ~830 MiB of Pandoc trees with the current API; [srid/emanote#66](https://github.com/srid/emanote/issues/66)), the handler returns one closure per file in the initial batch, and every closure — plus everything it captures — stays alive until the final fold runs. The model only ends up storing a small derived projection of each parsed Pandoc tree, but until the fold lands, the *whole batch* is in flight.

### Pain 2: handler can't read existing state

A handler that needs to look at the model to decide what to do with a change has no way to see it through `Change -> m (model -> model)`. The Lua-filter hot-reload path in [srid/emanote#263](https://github.com/srid/emanote/issues/263) needs exactly this: when a `.lua` filter file changes, the handler has to look up which notes referenced it (via a reverse-dependency index in the model) and re-parse those notes. Today downstream consumers paper over this by maintaining a parallel `TVar` mirror, then writing it from inside the change loop — duplicating state the library already owns internally.

## What

`unionMountStreaming :: ... -> model -> (Change source tag -> model -> m model) -> m (model, ...)`

The library hands the handler the current model and expects the next one. Both pains collapse into the new shape:

- The consumer can fold per-file updates through the model one at a time (so each file's closure is GC'd as soon as its update has been applied) — addresses pain 1.
- The handler reads the running model directly at every step — addresses pain 2.

Existing `unionMount` is unchanged at the API level (handler shape, return type, semantics). After commit `a5902c7`, it is implemented as a thin adapter onto `unionMountStreaming` — the transformer-returning shape is the lazy variant of the streaming shape — so there is exactly one place that owns the state fold and the remount loop.

## How

```haskell
-- Caller-side fold pattern for the streaming handler:
\change m -> foldlM step m (changeToList change)
  where step m c = do { f <- perFileHandler c m; pure $! f m }
```

Inside, `unionMountStreaming` wraps the existing `unionMount'` primitive (no model state; just a `Change` stream + a callback subscriber), maintains an `MVar` around the handler, and exposes the streaming-shaped subscribe loop:

```haskell
unionMountStreaming sources pats perSourceIgnore model0 handleAction = do
  (x0, xf) <- unionMount' sources pats perSourceIgnore
  initial <- interceptExceptions model0 $ handleAction x0 model0
  mvar <- newMVar initial
  let sender send = do
        Cmd_Remount <- xf $ \change -> do
          new <- modifyMVar mvar $ \old -> do
            new <- interceptExceptions old $ handleAction change old
            pure (new, new)
          send new
        ...
```

`unionMount` reduces to:

```haskell
unionMount sources pats perSourceIgnore model0 handleAction =
  unionMountStreaming sources pats perSourceIgnore model0 $ \change m -> do
    f <- handleAction change
    pure (f m)
```

The state primitive is `MVar` (via `UnliftIO.MVar.modifyMVar`), not `LVar`. `modifyMVar` runs the handler while holding the slot and uses `bracket` to restore the prior value on exception — so the get → handler → set transition is structurally atomic. `IORef` was the other candidate but its only safe combinator (`atomicModifyIORef'`) takes a pure `a -> (a, b)`, which would push the monadic handler outside the atomic boundary. (Closes [#18](https://github.com/srid/unionmount/issues/18).)

## Tests

Two regression tests for capabilities the current `unionMount` handler shape cannot express (no `model` arg) — they pass under `unionMountStreaming`:

- **Initial-batch fold**: handler records the model size *before* applying its own update for each of three files; observed sizes are `{0, 1, 2}` — the pre-step states as files are folded one at a time.
- **fsnotify-driven update**: a pre-existing file `a.txt` is in the model; `b.txt` is created at runtime; the handler firing for `b.txt` observes `a.txt` already in the model. This is the hot-reload reverse-index lookup pattern.

Vira CI green on x86_64-linux: 26/26 examples passing, treefmt-check clean, library and test-suite both build under the post-cleanup cabal manifest.

## History

The streaming function originally landed on the `issue-66-streaming-mount` branch in April 2026 motivated by the memory pain alone. This PR rebases that work onto current master (post [#16](https://github.com/srid/unionmount/pull/16)'s per-source-ignore signature), folds in the read-current-model framing that motivated revisiting it, adds the regression tests, collapses `unionMount` onto `unionMountStreaming` so the state fold and remount loop live in one place, and swaps the state primitive from `LVar` to `MVar` (closes #18).