### PR TITLE
Silence ignored live directory events

### DIFF
--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -270,7 +270,7 @@ unionMount' sources pats perSourceIgnore = do
           -- Run fsnotify on sources
           q :: TMVar (x, Maybe FilePath, FilePath, Either (FolderAction ()) (FileAction ())) <- liftIO newEmptyTMVarIO
           fmap (either id id) $
-            race (onChange q (toList sources)) $
+            race (onChange q (watchedRoot <$> toList sources)) $
               let readDebounced = do
                     -- Wait for some initial action in the queue.
                     _ <- atomically $ readTMVar q
@@ -282,20 +282,14 @@ unionMount' sources pats perSourceIgnore = do
                       =<< atomically (tryTakeTMVar q)
                   loop = do
                     (src, mountPoint, fp, actE) <- readDebounced
-                    let shouldIgnore = any (?== fp) (ignoreFor src)
                     case actE of
                       Left _ -> do
                         let reason = "Unhandled folder event on '" <> toText fp <> "'"
-                        if shouldIgnore
-                          then do
-                            log LevelWarn $ reason <> " on an ignored path"
-                            loop
-                          else do
-                            -- We don't know yet how to deal with folder events. Just reboot the mount.
-                            log LevelWarn $ reason <> "; suggesting a re-mount"
-                            pure Cmd_Remount -- Exit, asking user to remokunt
+                        -- We don't know yet how to deal with folder events. Just reboot the mount.
+                        log LevelWarn $ reason <> "; suggesting a re-mount"
+                        pure Cmd_Remount -- Exit, asking user to remokunt
                       Right act -> do
-                        case guard (not shouldIgnore) >> getTag pats fp of
+                        case getTag pats fp of
                           Nothing -> loop
                           Just tag -> do
                             changes <- fmap snd . flip runStateT Map.empty $ do
@@ -307,6 +301,12 @@ unionMount' sources pats perSourceIgnore = do
   where
     ignoreFor :: source -> [FilePattern]
     ignoreFor src = Map.findWithDefault [] src perSourceIgnore
+
+    ignoredBy :: source -> FilePath -> Bool
+    ignoredBy src fp = any (?== fp) (ignoreFor src)
+
+    watchedRoot :: (source, (FilePath, Maybe FilePath)) -> (source, (FilePath, Maybe FilePath), FilePath -> Bool)
+    watchedRoot (src, root) = (src, root, ignoredBy src)
 
 filesMatching :: (MonadIO m, MonadLogger m) => FilePath -> [FilePattern] -> [FilePattern] -> m [FilePath]
 filesMatching parent' pats ignore = do
@@ -356,13 +356,13 @@ onChange ::
   forall x m.
   (Eq x, MonadIO m, MonadLogger m, MonadUnliftIO m) =>
   TMVar (x, Maybe FilePath, FilePath, Either (FolderAction ()) (FileAction ())) ->
-  [(x, (FilePath, Maybe FilePath))] ->
+  [(x, (FilePath, Maybe FilePath), FilePath -> Bool)] ->
   -- | The filepath is relative to the folder being monitored, unless if its
   -- ancestor is a symlink.
   m Cmd
 onChange q roots = do
   withManagerM $ \mgr -> do
-    stops <- forM roots $ \(x, (rootRel, mountPoint)) -> do
+    stops <- forM roots $ \(x, (rootRel, mountPoint), shouldIgnore) -> do
       -- NOTE: It is important to use canonical path, because this will allow us to
       -- transform fsnotify event's (absolute) path into one that is relative to
       -- @parent'@ (as passed by user), which is what @f@ will expect.
@@ -376,26 +376,29 @@ onChange q roots = do
               f act = putTMVar q (x, mountPoint, fp, act)
               -- Re-add last item to the queue
               reAddQ = forM_ lastQ (putTMVar q)
-          if eventIsDirectory event == IsDirectory
-            then f $ Left $ FolderAction ()
-            else do
-              let newAction = case event of
-                    Added {} -> Just $ Refresh New ()
-                    Modified {} -> Just $ Refresh Update ()
-                    ModifiedAttributes {} -> Just $ Refresh Update ()
-                    Removed {} -> Just Delete
-                    _ -> Nothing
-              -- Merge with the last action when it makes sense to do so.
-              case (lastQ, newAction) of
-                (_, Nothing) -> reAddQ
-                (Just (lastTag, _lastMountPoint, lastFp, Right lastAction), Just a)
-                  | lastTag == x && lastFp == fp ->
-                      case (lastAction, a) of
-                        (Delete, Refresh New ()) -> f $ Right $ Refresh Update ()
-                        (Refresh New (), Refresh Update ()) -> f $ Right $ Refresh New ()
-                        (Refresh New (), Delete) -> pure ()
-                        _ -> f $ Right a
-                (_, Just a) -> reAddQ >> f (Right a)
+          if shouldIgnore fp
+            then reAddQ
+            else
+              if eventIsDirectory event == IsDirectory
+                then f $ Left $ FolderAction ()
+                else do
+                  let newAction = case event of
+                        Added {} -> Just $ Refresh New ()
+                        Modified {} -> Just $ Refresh Update ()
+                        ModifiedAttributes {} -> Just $ Refresh Update ()
+                        Removed {} -> Just Delete
+                        _ -> Nothing
+                  -- Merge with the last action when it makes sense to do so.
+                  case (lastQ, newAction) of
+                    (_, Nothing) -> reAddQ
+                    (Just (lastTag, _lastMountPoint, lastFp, Right lastAction), Just a)
+                      | lastTag == x && lastFp == fp ->
+                          case (lastAction, a) of
+                            (Delete, Refresh New ()) -> f $ Right $ Refresh Update ()
+                            (Refresh New (), Refresh Update ()) -> f $ Right $ Refresh New ()
+                            (Refresh New (), Delete) -> pure ()
+                            _ -> f $ Right a
+                    (_, Just a) -> reAddQ >> f (Right a)
     liftIO (threadDelay maxBound)
       `finally` do
         log LevelInfo "Stopping fsnotify monitor."

--- a/src/System/UnionMount.hs
+++ b/src/System/UnionMount.hs
@@ -368,37 +368,36 @@ onChange q roots = do
       -- @parent'@ (as passed by user), which is what @f@ will expect.
       root <- liftIO $ canonicalizePath rootRel
       log LevelInfo $ toText $ "Monitoring " <> root <> " for changes"
-      watchTreeM mgr root (const True) $ \event -> do
+      let relativePath = makeRelative root . eventPath
+          admitEvent = not . shouldIgnore . relativePath
+      watchTreeM mgr root admitEvent $ \event -> do
         log LevelDebug $ show event
         atomically $ do
           lastQ <- tryTakeTMVar q
-          let fp = makeRelative root $ eventPath event
+          let fp = relativePath event
               f act = putTMVar q (x, mountPoint, fp, act)
               -- Re-add last item to the queue
               reAddQ = forM_ lastQ (putTMVar q)
-          if shouldIgnore fp
-            then reAddQ
-            else
-              if eventIsDirectory event == IsDirectory
-                then f $ Left $ FolderAction ()
-                else do
-                  let newAction = case event of
-                        Added {} -> Just $ Refresh New ()
-                        Modified {} -> Just $ Refresh Update ()
-                        ModifiedAttributes {} -> Just $ Refresh Update ()
-                        Removed {} -> Just Delete
-                        _ -> Nothing
-                  -- Merge with the last action when it makes sense to do so.
-                  case (lastQ, newAction) of
-                    (_, Nothing) -> reAddQ
-                    (Just (lastTag, _lastMountPoint, lastFp, Right lastAction), Just a)
-                      | lastTag == x && lastFp == fp ->
-                          case (lastAction, a) of
-                            (Delete, Refresh New ()) -> f $ Right $ Refresh Update ()
-                            (Refresh New (), Refresh Update ()) -> f $ Right $ Refresh New ()
-                            (Refresh New (), Delete) -> pure ()
-                            _ -> f $ Right a
-                    (_, Just a) -> reAddQ >> f (Right a)
+          if eventIsDirectory event == IsDirectory
+            then f $ Left $ FolderAction ()
+            else do
+              let newAction = case event of
+                    Added {} -> Just $ Refresh New ()
+                    Modified {} -> Just $ Refresh Update ()
+                    ModifiedAttributes {} -> Just $ Refresh Update ()
+                    Removed {} -> Just Delete
+                    _ -> Nothing
+              -- Merge with the last action when it makes sense to do so.
+              case (lastQ, newAction) of
+                (_, Nothing) -> reAddQ
+                (Just (lastTag, _lastMountPoint, lastFp, Right lastAction), Just a)
+                  | lastTag == x && lastFp == fp ->
+                      case (lastAction, a) of
+                        (Delete, Refresh New ()) -> f $ Right $ Refresh Update ()
+                        (Refresh New (), Refresh Update ()) -> f $ Right $ Refresh New ()
+                        (Refresh New (), Delete) -> pure ()
+                        _ -> f $ Right a
+                (_, Just a) -> reAddQ >> f (Right a)
     liftIO (threadDelay maxBound)
       `finally` do
         log LevelInfo "Stopping fsnotify monitor."

--- a/test/System/UnionMountSpec.hs
+++ b/test/System/UnionMountSpec.hs
@@ -3,7 +3,8 @@
 
 module System.UnionMountSpec where
 
-import Control.Monad.Logger.Extras (logToNowhere, runLoggerLoggingT)
+import Control.Monad.Logger (LogLevel (LevelWarn))
+import Control.Monad.Logger.Extras (Logger (Logger), logToNowhere, runLoggerLoggingT)
 import Data.LVar qualified as LVar
 import Data.List (stripPrefix)
 import Data.List.NonEmpty qualified as NE
@@ -11,7 +12,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Traversable (for)
 import Relude.Unsafe qualified as Unsafe
-import System.Directory (createDirectory)
+import System.Directory (createDirectory, createDirectoryIfMissing)
 import System.Directory.Recursive (getFilesRecursive)
 import System.FilePath ((</>))
 import System.FilePattern (FilePattern, (?==))
@@ -199,6 +200,45 @@ spec = do
           finalModel <- LVar.get model
           Map.lookup "secret.txt" finalModel `shouldBe` Just ["B"]
           Map.lookup "public.txt" finalModel `shouldBe` Just ["A"]
+    it "ignored live folder events do not warn or block later file events" $ do
+      withSystemTempDirectory "ignoredFolderLive" $ \dir -> do
+        createDirectoryIfMissing True (dir </> ".git" </> "objects")
+        model <- LVar.empty
+        warnCount <- newIORef (0 :: Int)
+        let layers = Set.singleton (dir :: FilePath, (dir, Nothing))
+            pats = [((), "*.txt")]
+            perSource = Map.singleton dir ["**/.*/**"]
+            countWarnings = Logger $ \_ _ level _ ->
+              when (level == LevelWarn) $
+                atomicModifyIORef' warnCount $
+                  \n -> (n + 1, ())
+            applyChange change =
+              pure $
+                \m0 ->
+                  foldl'
+                    ( \m (fp, act) ->
+                        case act of
+                          UM.Delete -> Set.delete fp m
+                          UM.Refresh {} -> Set.insert fp m
+                    )
+                    m0
+                    (Map.toList $ Map.findWithDefault mempty () change)
+        flip runLoggerLoggingT countWarnings $ do
+          (model0, patch) <- UM.unionMount layers pats perSource Set.empty applyChange
+          LVar.set model model0
+          race_
+            (patch $ LVar.set model)
+            ( do
+                threadDelay fsnotifyWatcherSetupDelay
+                liftIO $ createDirectory (dir </> ".git" </> "objects" </> "3b")
+                threadDelay 300_000
+                writeFile (dir </> "public.txt") "visible"
+                _ <- waitForModel model (Set.singleton "public.txt")
+                pass
+            )
+        finalModel <- LVar.get model
+        finalModel `shouldBe` Set.singleton "public.txt"
+        readIORef warnCount `shouldReturn` 0
   describe "unionMountStreaming" $ do
     it "handler observes the running model when folding the initial batch" $ do
       -- Three files; handler reads the model size *before* applying its own


### PR DESCRIPTION
**Ignored directories no longer surface as live watcher warnings** when fsnotify reports folder events under paths like `.git/objects`. The ignore predicate now runs at the watcher admission boundary, so ignored events never enter the debounce queue while nonignored directory events still request remounts.

The live watcher now receives the same per-source ignore predicate that powers the initial scan. A regression test creates `.git/objects/3b`, verifies no warning is emitted, and then writes `public.txt` to prove normal file updates still flow.

### Try it locally

```sh
nix build github:srid/unionmount/fix-ignore-folder-events
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._